### PR TITLE
chore: bump version to 0.1.2, remove auto-loop for next task

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentrq/acp-gateway",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.19.0",
+        "@agentrq/acp-gateway": "^0.1.2",
         "@modelcontextprotocol/sdk": "^1.10.0"
       },
       "bin": {
@@ -32,6 +33,21 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@agentrq/acp-gateway": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@agentrq/acp-gateway/-/acp-gateway-0.1.2.tgz",
+      "integrity": "sha512-Mlr/IZnvWl1Yfv3iJooz7sYitHqN5aAO6UdEVqucz9TA6qG9CwlPxyGBUt8Xu2g3Kp1UkkK0uzX/lDECHUX+tQ==",
+      "dependencies": {
+        "@agentclientprotocol/sdk": "^0.19.0",
+        "@modelcontextprotocol/sdk": "^1.10.0"
+      },
+      "bin": {
+        "acp-gateway": "dist/index.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "ACP+MCP bridge CLI for agentrq workspaces",
   "type": "module",
   "publishConfig": {
@@ -39,6 +39,7 @@
   ],
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.19.0",
+    "@agentrq/acp-gateway": "^0.1.2",
     "@modelcontextprotocol/sdk": "^1.10.0"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,9 +107,6 @@ async function main() {
         console.error(
           `\n[acp] Agent completed task. Reason: ${result.stopReason}`,
         );
-
-        // Loop: When a task is complete, automatically ask for the next one
-        await checkForNextTask(mcpBridge, connection, sessionId);
       } catch (err) {
         console.error("[acp] Error during prompt execution:", err);
       }


### PR DESCRIPTION
No need to check next task on completion; the server will push it already.