### PR TITLE
feat: map MCP server headers and env to ACP format

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,7 +1,83 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { createAcpSessionSwitcher, checkForNextTask } from "../index.js";
+import { createAcpSessionSwitcher, checkForNextTask, mapMcpServers } from "../index.js";
+import type { McpServerConfig } from "../config.js";
 
 describe("index", () => {
+  describe("mapMcpServers", () => {
+    it("should correctly map HTTP servers with headers and env", () => {
+      const configs: McpServerConfig[] = [{
+        type: "http",
+        name: "test-http",
+        url: "http://localhost:8000",
+        env: { "Authorization": "Bearer env-token", "Other": "Val" },
+        headers: { "Authorization": "Bearer header-token", "Custom": "Header" }
+      }];
+      const result = mapMcpServers(configs);
+      expect(result).toEqual([{
+        type: "http",
+        name: "test-http",
+        url: "http://localhost:8000",
+        headers: [
+          { name: "Authorization", value: "Bearer header-token" },
+          { name: "Custom", value: "Header" }
+        ]
+      }]);
+    });
+
+    it("should default headers to empty object for HTTP servers", () => {
+      const configs: McpServerConfig[] = [{
+        type: "http",
+        name: "test-http",
+        url: "http://localhost:8000"
+      }];
+      const result = mapMcpServers(configs);
+      expect(result).toEqual([{
+        type: "http",
+        name: "test-http",
+        url: "http://localhost:8000",
+        headers: []
+      }]);
+    });
+
+    it("should correctly map stdio servers", () => {
+      const configs: McpServerConfig[] = [{
+        type: "stdio",
+        name: "test-stdio",
+        command: "npx",
+        args: ["-y", "some-pkg"],
+        env: {
+          API_KEY: "secret",
+          MODE: "test"
+        }
+      }];
+      const result = mapMcpServers(configs);
+      expect(result).toEqual([{
+        name: "test-stdio",
+        command: "npx",
+        args: ["-y", "some-pkg"],
+        env: [
+          { name: "API_KEY", value: "secret" },
+          { name: "MODE", value: "test" }
+        ]
+      }]);
+    });
+
+    it("should default args to empty array and env to empty object for stdio servers", () => {
+      const configs: McpServerConfig[] = [{
+        type: "stdio",
+        name: "minimal-stdio",
+        command: "echo"
+      }];
+      const result = mapMcpServers(configs);
+      expect(result).toEqual([{
+        name: "minimal-stdio",
+        command: "echo",
+        args: [],
+        env: []
+      }]);
+    });
+  });
+
   describe("createAcpSessionSwitcher", () => {
     let mockConnection: any;
     let params: any;

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ export interface McpServerConfig {
   command?: string;
   args?: string[];
   env?: Record<string, string>;
+  headers?: Record<string, string>;
 }
 
 interface McpJson {
@@ -26,6 +27,7 @@ interface McpJson {
       command?: string;
       args?: string[];
       env?: Record<string, string>;
+      headers?: Record<string, string>;
     }
   >;
 }
@@ -55,6 +57,7 @@ export function loadMcpConfig(startDir: string = process.cwd()): McpServerConfig
         command: cfg.command,
         args: cfg.args,
         env: cfg.env,
+        headers: cfg.headers,
       }));
 
       if (servers.length > 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,8 +14,28 @@ const pkg = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
 );
 
-import { loadMcpConfig, pickAgentrqServer } from "./config.js";
+import { loadMcpConfig, pickAgentrqServer, type McpServerConfig } from "./config.js";
 import { MCPBridge } from "./mcpClient.js";
+
+export function mapMcpServers(configs: McpServerConfig[]): acp.McpServer[] {
+  return configs.map((cfg): acp.McpServer => {
+    if (cfg.type === "http") {
+      return {
+        type: "http",
+        name: cfg.name,
+        url: cfg.url!,
+        headers: Object.entries(cfg.headers || {}).map(([name, value]) => ({ name, value })) as any,
+      };
+    } else {
+      return {
+        name: cfg.name,
+        command: cfg.command!,
+        args: cfg.args ?? [],
+        env: Object.entries(cfg.env || {}).map(([name, value]) => ({ name, value })) as any,
+      };
+    }
+  });
+}
 import { AgentRQACPClient } from "./acpClient.js";
 import {
   extractTaskIdFromMeta,
@@ -121,14 +141,7 @@ async function main() {
     // The McpServer object must follow the ACP protocol schema (type, name, url, headers).
     const newSessionParams: AcpNewSessionParams = {
       cwd: process.cwd(),
-      mcpServers: [
-        {
-          type: "http",
-          name: agentrqConfig.name,
-          url: agentrqConfig.url!,
-          headers: [],
-        },
-      ],
+      mcpServers: mapMcpServers(configs),
     };
 
     const sessionResult = await connection.newSession(newSessionParams);


### PR DESCRIPTION
- Maps `headers` for HTTP servers to an array of `{ name, value }` objects.
- Removes `env` from HTTP servers as it's not supported by the schema.
- Maps `env` for stdio servers to an array of `{ name, value }` objects.