### PR TITLE
fix: route MCP task updates to the correct active agent session

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.14",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.19.0",
-        "@agentrq/acp-gateway": "^0.1.1",
         "@modelcontextprotocol/sdk": "^1.10.0"
       },
       "bin": {
@@ -33,22 +32,6 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
-      }
-    },
-    "node_modules/@agentrq/acp-gateway": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@agentrq/acp-gateway/-/acp-gateway-0.1.14.tgz",
-      "integrity": "sha512-3VRU6qxKSKRAatFeGaeGloWesMU91vL3EBbhu+UKVZsO8sfxTo/L+Kjo6Q/H8uMYQ60I+hMbRyGysZs3tu1efA==",
-      "dependencies": {
-        "@agentclientprotocol/sdk": "^0.19.0",
-        "@agentrq/acp-gateway": "^0.1.1",
-        "@modelcontextprotocol/sdk": "^1.10.0"
-      },
-      "bin": {
-        "acp-gateway": "dist/index.js"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   ],
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.19.0",
-    "@agentrq/acp-gateway": "^0.1.1",
     "@modelcontextprotocol/sdk": "^1.10.0"
   },
   "devDependencies": {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -116,16 +116,35 @@ describe("index", () => {
     it("should create a new session when taskId changes", async () => {
       params = { cwd: "/test", mcpServers: [{ name: "s1", url: "http://s1", headers: [] }] };
       const switcher = createAcpSessionSwitcher(mockConnection, params, "initial-id");
-      
+
       // Set initial task
       await switcher.ensureForTask("task-1");
-      
+
       // Change task
       const id = await switcher.ensureForTask("task-2");
-      
+
       expect(id).toBe("new-session-id");
       expect(mockConnection.newSession).toHaveBeenCalledTimes(2);
       expect(switcher.getSessionId()).toBe("new-session-id");
+    });
+
+    it("should return existing session when a previously seen task returns", async () => {
+      mockConnection.newSession
+        .mockResolvedValueOnce({ sessionId: "session-for-task-1" })
+        .mockResolvedValueOnce({ sessionId: "session-for-task-2" });
+
+      const switcher = createAcpSessionSwitcher(mockConnection, params, "initial-id");
+
+      const id1 = await switcher.ensureForTask("task-1");
+      expect(id1).toBe("session-for-task-1");
+
+      const id2 = await switcher.ensureForTask("task-2");
+      expect(id2).toBe("session-for-task-2");
+
+      // task-1 returns — must reuse session-for-task-1, not create a third session
+      const id3 = await switcher.ensureForTask("task-1");
+      expect(id3).toBe("session-for-task-1");
+      expect(mockConnection.newSession).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,25 +51,31 @@ export function createAcpSessionSwitcher(
   params: AcpNewSessionParams,
   initialSessionId: string,
 ) {
-  let sessionId = initialSessionId;
-  let activeTaskId: string | undefined = undefined;
+  let currentSessionId = initialSessionId;
+  const taskSessionMap = new Map<string, string>();
 
   return {
     getSessionId(): string {
-      return sessionId;
+      return currentSessionId;
     },
     async ensureForTask(taskId: string | undefined): Promise<string> {
-      if (taskId === activeTaskId) {
-        return sessionId;
+      if (taskId === undefined) {
+        return currentSessionId;
+      }
+
+      const existing = taskSessionMap.get(taskId);
+      if (existing) {
+        currentSessionId = existing;
+        return existing;
       }
 
       const next = await connection.newSession(params);
-      sessionId = next.sessionId;
-      activeTaskId = taskId;
+      currentSessionId = next.sessionId;
+      taskSessionMap.set(taskId, currentSessionId);
       console.error(
-        `[acp] New ACP session for task ${taskId ?? "anonymous"} (MCP connection unchanged): ${sessionId}`,
+        `[acp] New ACP session for task ${taskId} (MCP connection unchanged): ${currentSessionId}`,
       );
-      return sessionId;
+      return currentSessionId;
     },
   };
 }


### PR DESCRIPTION
Replace the single activeTaskId/sessionId slot in createAcpSessionSwitcher with a Map<taskId, sessionId> so follow-up messages for a previously-seen task reuse its existing ACP session rather than opening a new one.

Also removes the self-referential @agentrq/acp-gateway dependency from package.json and package-lock.json.