### PR TITLE
feat: forward agent replies to corresponding AgentRQ task via reply M…

### DIFF
--- a/src/__tests__/acpClient.test.ts
+++ b/src/__tests__/acpClient.test.ts
@@ -218,6 +218,7 @@ describe("AgentRQACPClient", () => {
         .spyOn(process.stdout, "write")
         .mockImplementation(() => true);
       const params = {
+        sessionId: "sess-1",
         update: {
           sessionUpdate: "agent_message_chunk",
           content: { type: "text", text: "hello" },
@@ -234,6 +235,7 @@ describe("AgentRQACPClient", () => {
         .spyOn(process.stdout, "write")
         .mockImplementation(() => true);
       const params = {
+        sessionId: "sess-1",
         update: {
           sessionUpdate: "agent_message_chunk",
           content: { type: "other", text: "ignored" },
@@ -284,6 +286,50 @@ describe("AgentRQACPClient", () => {
     it("should handle unknown update types", async () => {
       const params = { update: { sessionUpdate: "unknown" } } as any;
       await expect(client.sessionUpdate(params)).resolves.toBeUndefined();
+    });
+  });
+
+  describe("flushReply", () => {
+    it("should call reply tool with accumulated text and clear the buffer", async () => {
+      mcpBridge.callTool = vi.fn().mockResolvedValue({ isError: false, content: [] });
+      const getTaskId = vi.fn().mockReturnValue("task-123");
+      const c = new AgentRQACPClient(mcpBridge as unknown as MCPBridge, getTaskId);
+      vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+      await c.sessionUpdate({ sessionId: "sess-1", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Hello " } } } as any);
+      await c.sessionUpdate({ sessionId: "sess-1", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "world" } } } as any);
+
+      await c.flushReply("sess-1");
+
+      expect(mcpBridge.callTool).toHaveBeenCalledWith("reply", { chatId: "task-123", text: "Hello world" });
+
+      // Buffer cleared — second flush should not call reply again
+      mcpBridge.callTool.mockClear();
+      await c.flushReply("sess-1");
+      expect(mcpBridge.callTool).not.toHaveBeenCalled();
+    });
+
+    it("should skip reply if buffer is empty", async () => {
+      mcpBridge.callTool = vi.fn();
+      const c = new AgentRQACPClient(mcpBridge as unknown as MCPBridge, () => "task-123");
+
+      await c.flushReply("sess-empty");
+
+      expect(mcpBridge.callTool).not.toHaveBeenCalled();
+    });
+
+    it("should skip reply if no task ID is found for the session", async () => {
+      mcpBridge.callTool = vi.fn();
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const c = new AgentRQACPClient(mcpBridge as unknown as MCPBridge, () => undefined);
+      vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+      await c.sessionUpdate({ sessionId: "sess-unknown", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "hi" } } } as any);
+      await c.flushReply("sess-unknown");
+
+      expect(mcpBridge.callTool).not.toHaveBeenCalled();
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("No task ID for session"));
+      consoleSpy.mockRestore();
     });
   });
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -148,10 +148,44 @@ describe("index", () => {
     });
   });
 
+  describe("createAcpSessionSwitcher – getTaskIdForSession", () => {
+    let mockConnection: any;
+    let params: any;
+
+    beforeEach(() => {
+      mockConnection = {
+        newSession: vi.fn()
+          .mockResolvedValueOnce({ sessionId: "session-for-task-1" })
+          .mockResolvedValueOnce({ sessionId: "session-for-task-2" }),
+      };
+      params = { cwd: "/test", mcpServers: [] };
+    });
+
+    it("should return taskId for a known session", async () => {
+      const switcher = createAcpSessionSwitcher(mockConnection, params, "initial-id");
+      await switcher.ensureForTask("task-1");
+      expect(switcher.getTaskIdForSession("session-for-task-1")).toBe("task-1");
+    });
+
+    it("should return undefined for an unknown session", async () => {
+      const switcher = createAcpSessionSwitcher(mockConnection, params, "initial-id");
+      expect(switcher.getTaskIdForSession("unknown-session")).toBeUndefined();
+    });
+
+    it("should track multiple sessions independently", async () => {
+      const switcher = createAcpSessionSwitcher(mockConnection, params, "initial-id");
+      await switcher.ensureForTask("task-1");
+      await switcher.ensureForTask("task-2");
+      expect(switcher.getTaskIdForSession("session-for-task-1")).toBe("task-1");
+      expect(switcher.getTaskIdForSession("session-for-task-2")).toBe("task-2");
+    });
+  });
+
   describe("checkForNextTask", () => {
     let mockMcpBridge: any;
     let mockConnection: any;
     let mockSessionSwitcher: any;
+    let mockAcpClient: any;
 
     beforeEach(() => {
       vi.clearAllMocks();
@@ -165,6 +199,9 @@ describe("index", () => {
         getSessionId: vi.fn().mockReturnValue("current-session"),
         ensureForTask: vi.fn().mockResolvedValue("current-session"),
       };
+      mockAcpClient = {
+        flushReply: vi.fn().mockResolvedValue(undefined),
+      };
 
       // Mock console.error to avoid cluttering test output
       vi.spyOn(console, "error").mockImplementation(() => {});
@@ -176,7 +213,7 @@ describe("index", () => {
         content: [{ type: "text", text: "no pending tasks exist" }],
       });
 
-      await checkForNextTask(mockMcpBridge, mockConnection, mockSessionSwitcher);
+      await checkForNextTask(mockMcpBridge, mockConnection, mockSessionSwitcher, mockAcpClient);
 
       expect(mockMcpBridge.callTool).toHaveBeenCalledWith("getNextTask");
       expect(mockConnection.prompt).not.toHaveBeenCalled();
@@ -188,7 +225,7 @@ describe("index", () => {
         content: "some error",
       });
 
-      await checkForNextTask(mockMcpBridge, mockConnection, mockSessionSwitcher);
+      await checkForNextTask(mockMcpBridge, mockConnection, mockSessionSwitcher, mockAcpClient);
 
       expect(mockMcpBridge.callTool).toHaveBeenCalledWith("getNextTask");
       expect(mockConnection.prompt).not.toHaveBeenCalled();
@@ -206,7 +243,7 @@ describe("index", () => {
           content: [{ type: "text", text: "no pending tasks exist" }],
         });
 
-      await checkForNextTask(mockMcpBridge, mockConnection, mockSessionSwitcher);
+      await checkForNextTask(mockMcpBridge, mockConnection, mockSessionSwitcher, mockAcpClient);
 
       expect(mockMcpBridge.callTool).toHaveBeenCalledTimes(2);
       expect(mockSessionSwitcher.ensureForTask).toHaveBeenCalledWith("T1");
@@ -214,12 +251,13 @@ describe("index", () => {
         sessionId: "current-session",
         prompt: [{ type: "text", text: "Task ID: T1\ndo something" }],
       });
+      expect(mockAcpClient.flushReply).toHaveBeenCalledWith("current-session");
     });
 
     it("should handle exceptions during execution", async () => {
       mockMcpBridge.callTool.mockRejectedValue(new Error("network error"));
 
-      await checkForNextTask(mockMcpBridge, mockConnection, mockSessionSwitcher);
+      await checkForNextTask(mockMcpBridge, mockConnection, mockSessionSwitcher, mockAcpClient);
 
       expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining("Failed to check for next task"),

--- a/src/acpClient.ts
+++ b/src/acpClient.ts
@@ -11,7 +11,31 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
 export class AgentRQACPClient implements acp.Client {
-  constructor(private mcpBridge: MCPBridge) {}
+  private replyBuffers = new Map<string, string>();
+
+  constructor(
+    private mcpBridge: MCPBridge,
+    private getTaskIdForSession: (sessionId: string) => string | undefined = () => undefined,
+  ) {}
+
+  async flushReply(sessionId: string): Promise<void> {
+    const text = this.replyBuffers.get(sessionId) ?? "";
+    this.replyBuffers.delete(sessionId);
+    if (!text.trim()) return;
+
+    const taskId = this.getTaskIdForSession(sessionId);
+    if (!taskId) {
+      console.error(`[acp] No task ID for session ${sessionId}, skipping reply`);
+      return;
+    }
+
+    try {
+      await this.mcpBridge.callTool("reply", { chatId: taskId, text });
+      console.error(`[acp] Forwarded agent reply to task ${taskId}`);
+    } catch (err) {
+      console.error(`[acp] Failed to forward reply to task ${taskId}:`, err);
+    }
+  }
 
   async requestPermission(
     params: acp.RequestPermissionRequest
@@ -98,6 +122,8 @@ export class AgentRQACPClient implements acp.Client {
       case "agent_message_chunk":
         if (update.content.type === "text") {
           process.stdout.write(update.content.text);
+          const sid = params.sessionId;
+          this.replyBuffers.set(sid, (this.replyBuffers.get(sid) ?? "") + update.content.text);
         }
         break;
       case "tool_call":

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,10 +53,14 @@ export function createAcpSessionSwitcher(
 ) {
   let currentSessionId = initialSessionId;
   const taskSessionMap = new Map<string, string>();
+  const sessionTaskMap = new Map<string, string>();
 
   return {
     getSessionId(): string {
       return currentSessionId;
+    },
+    getTaskIdForSession(sessionId: string): string | undefined {
+      return sessionTaskMap.get(sessionId);
     },
     async ensureForTask(taskId: string | undefined): Promise<string> {
       if (taskId === undefined) {
@@ -72,6 +76,7 @@ export function createAcpSessionSwitcher(
       const next = await connection.newSession(params);
       currentSessionId = next.sessionId;
       taskSessionMap.set(taskId, currentSessionId);
+      sessionTaskMap.set(currentSessionId, taskId);
       console.error(
         `[acp] New ACP session for task ${taskId} (MCP connection unchanged): ${currentSessionId}`,
       );
@@ -119,7 +124,9 @@ async function main() {
   ) as ReadableStream<Uint8Array>;
 
   // 4. Create ACP Connection
-  const acpClient = new AgentRQACPClient(mcpBridge);
+  // taskIdLookup is filled in after the session switcher is created below.
+  let taskIdLookup: (sessionId: string) => string | undefined = () => undefined;
+  const acpClient = new AgentRQACPClient(mcpBridge, (sid) => taskIdLookup(sid));
   const stream = acp.ndJsonStream(input, output);
   const connection = new acp.ClientSideConnection(
     (_agent) => acpClient,
@@ -157,6 +164,7 @@ async function main() {
       newSessionParams,
       sessionResult.sessionId,
     );
+    taskIdLookup = (sid) => sessionSwitcher.getTaskIdForSession(sid);
     console.error(`[acp] Created session: ${sessionSwitcher.getSessionId()}`);
 
     // Bridge: MCP -> ACP
@@ -174,6 +182,7 @@ async function main() {
           prompt: [{ type: "text", text: content }],
         });
 
+        await acpClient.flushReply(sessionId);
         console.error(
           `\n[acp] Agent completed task. Reason: ${result.stopReason}`,
         );
@@ -183,7 +192,7 @@ async function main() {
     });
 
     // Initial check for a pending task
-    await checkForNextTask(mcpBridge, connection, sessionSwitcher);
+    await checkForNextTask(mcpBridge, connection, sessionSwitcher, acpClient);
 
     // Keep the process alive
     await new Promise(() => {});
@@ -204,6 +213,7 @@ export async function checkForNextTask(
   mcpBridge: MCPBridge,
   connection: acp.ClientSideConnection,
   sessionSwitcher: ReturnType<typeof createAcpSessionSwitcher>,
+  acpClient: AgentRQACPClient,
 ) {
   console.error("[bridge] Checking for next task via MCP server...");
   try {
@@ -236,10 +246,11 @@ export async function checkForNextTask(
         prompt: [{ type: "text", text }],
       });
 
+      await acpClient.flushReply(sessionId);
       console.error(`\n[acp] Agent completed with: ${promptResult.stopReason}`);
 
       // Recursively check for next task
-      await checkForNextTask(mcpBridge, connection, sessionSwitcher);
+      await checkForNextTask(mcpBridge, connection, sessionSwitcher, acpClient);
     } else {
       console.error("[bridge] No pending tasks available.");
     }


### PR DESCRIPTION
…CP tool

- Add sessionTaskMap (sessionId → taskId) reverse mapping to createAcpSessionSwitcher and expose getTaskIdForSession() for lookup
- AgentRQACPClient buffers agent_message_chunk text per session in sessionUpdate
- AgentRQACPClient.flushReply(sessionId) sends the accumulated text to the matching task using the reply MCP tool, then clears the buffer
- Wire flushReply() call after every connection.prompt() in both the task event handler and checkForNextTask