### PR TITLE
fix: skip flushReply when agent already sent identical reply via MCP …

### DIFF
--- a/src/__tests__/acpClient.test.ts
+++ b/src/__tests__/acpClient.test.ts
@@ -331,6 +331,82 @@ describe("AgentRQACPClient", () => {
       expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("No task ID for session"));
       consoleSpy.mockRestore();
     });
+
+    it("should skip reply when agent already sent identical reply via tool call", async () => {
+      mcpBridge.callTool = vi.fn().mockResolvedValue({ isError: false, content: [] });
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const c = new AgentRQACPClient(mcpBridge as unknown as MCPBridge, () => "task-123");
+      vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+      // Agent buffers text
+      await c.sessionUpdate({ sessionId: "sess-1", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Hello world" } } } as any);
+
+      // Agent also called reply via MCP tool with identical params
+      await c.sessionUpdate({
+        sessionId: "sess-1",
+        update: {
+          sessionUpdate: "tool_call",
+          title: "reply (agentrq-0an2BXTfpGj MCP Server)",
+          status: "completed",
+          toolCallId: "tc-1",
+          rawInput: { chatId: "task-123", text: "Hello world" },
+        },
+      } as any);
+
+      await c.flushReply("sess-1");
+
+      expect(mcpBridge.callTool).not.toHaveBeenCalledWith("reply", expect.anything());
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("agent already sent identical reply"));
+      consoleSpy.mockRestore();
+    });
+
+    it("should still send reply when agent called reply with different text", async () => {
+      mcpBridge.callTool = vi.fn().mockResolvedValue({ isError: false, content: [] });
+      const c = new AgentRQACPClient(mcpBridge as unknown as MCPBridge, () => "task-123");
+      vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+      await c.sessionUpdate({ sessionId: "sess-1", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Full verbose output" } } } as any);
+
+      // Agent sent a different message via reply tool
+      await c.sessionUpdate({
+        sessionId: "sess-1",
+        update: {
+          sessionUpdate: "tool_call",
+          title: "reply (agentrq-0an2BXTfpGj MCP Server)",
+          status: "completed",
+          toolCallId: "tc-1",
+          rawInput: { chatId: "task-123", text: "Summary only" },
+        },
+      } as any);
+
+      await c.flushReply("sess-1");
+
+      expect(mcpBridge.callTool).toHaveBeenCalledWith("reply", { chatId: "task-123", text: "Full verbose output" });
+    });
+
+    it("should not skip reply if agent tool call was not completed", async () => {
+      mcpBridge.callTool = vi.fn().mockResolvedValue({ isError: false, content: [] });
+      const c = new AgentRQACPClient(mcpBridge as unknown as MCPBridge, () => "task-123");
+      vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+      await c.sessionUpdate({ sessionId: "sess-1", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Hello world" } } } as any);
+
+      // Tool call is in_progress, not completed
+      await c.sessionUpdate({
+        sessionId: "sess-1",
+        update: {
+          sessionUpdate: "tool_call",
+          title: "reply (agentrq-0an2BXTfpGj MCP Server)",
+          status: "in_progress",
+          toolCallId: "tc-1",
+          rawInput: { chatId: "task-123", text: "Hello world" },
+        },
+      } as any);
+
+      await c.flushReply("sess-1");
+
+      expect(mcpBridge.callTool).toHaveBeenCalledWith("reply", { chatId: "task-123", text: "Hello world" });
+    });
   });
 
   describe("file operations", () => {

--- a/src/acpClient.ts
+++ b/src/acpClient.ts
@@ -12,6 +12,8 @@ import * as path from "node:path";
 
 export class AgentRQACPClient implements acp.Client {
   private replyBuffers = new Map<string, string>();
+  // chatId → text sent by the agent via the reply MCP tool (for dedup in flushReply)
+  private agentReplies = new Map<string, string>();
 
   constructor(
     private mcpBridge: MCPBridge,
@@ -26,6 +28,13 @@ export class AgentRQACPClient implements acp.Client {
     const taskId = this.getTaskIdForSession(sessionId);
     if (!taskId) {
       console.error(`[acp] No task ID for session ${sessionId}, skipping reply`);
+      return;
+    }
+
+    const agentReplyText = this.agentReplies.get(taskId);
+    this.agentReplies.delete(taskId);
+    if (agentReplyText !== undefined && agentReplyText === text) {
+      console.error(`[acp] Skipping reply to task ${taskId} — agent already sent identical reply`);
       return;
     }
 
@@ -126,14 +135,24 @@ export class AgentRQACPClient implements acp.Client {
           this.replyBuffers.set(sid, (this.replyBuffers.get(sid) ?? "") + update.content.text);
         }
         break;
-      case "tool_call":
-        // Skip logging for auto-allowed tools to avoid noise in the backend/logs
+      case "tool_call": {
         const agentrqToolPattern = /agentrq-[a-zA-Z0-9]{11}/;
         if (update.title && agentrqToolPattern.test(update.title)) {
+          // Track completed reply calls so flushReply can skip exact duplicates
+          if (
+            update.status === "completed" &&
+            update.title.split(/[\s(]/)[0] === "reply" &&
+            update.rawInput != null &&
+            typeof (update.rawInput as any).chatId === "string"
+          ) {
+            const { chatId, text = "" } = update.rawInput as { chatId: string; text?: string };
+            this.agentReplies.set(chatId, text);
+          }
           break;
         }
         console.error(`\n🔧 [ACP Agent] Tool call: ${update.title} (${update.status})`);
         break;
+      }
       default:
         break;
     }


### PR DESCRIPTION
…tool

Track completed reply tool calls in sessionUpdate (chatId → text). In flushReply, if the agent already sent an exact-match reply for the same chatId, skip the redundant call and clear the tracking entry.