### PR TITLE
fix: use merged getTask MCP tool instead of removed getNextTask

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -247,7 +247,7 @@ describe("index", () => {
 
       await checkForNextTask(mockMcpBridge, mockConnection, mockSessionSwitcher, mockAcpClient);
 
-      expect(mockMcpBridge.callTool).toHaveBeenCalledWith("getNextTask");
+      expect(mockMcpBridge.callTool).toHaveBeenCalledWith("getTask");
       expect(mockConnection.prompt).not.toHaveBeenCalled();
     });
 
@@ -259,7 +259,7 @@ describe("index", () => {
 
       await checkForNextTask(mockMcpBridge, mockConnection, mockSessionSwitcher, mockAcpClient);
 
-      expect(mockMcpBridge.callTool).toHaveBeenCalledWith("getNextTask");
+      expect(mockMcpBridge.callTool).toHaveBeenCalledWith("getTask");
       expect(mockConnection.prompt).not.toHaveBeenCalled();
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -320,7 +320,8 @@ async function main() {
 }
 
 /**
- * Checks for the next pending task using the 'getNextTask' tool on the MCP server.
+ * Checks for the next pending task using the 'getTask' tool on the MCP server.
+ * Called with no taskId, 'getTask' dequeues the next not-started task.
  * If found, sends it to the ACP agent.
  */
 export async function checkForNextTask(
@@ -335,7 +336,7 @@ export async function checkForNextTask(
 ) {
   console.error("[bridge] Checking for next task via MCP server...");
   try {
-    const result = await mcpBridge.callTool("getNextTask");
+    const result = await mcpBridge.callTool("getTask");
 
     if (result.isError) {
       console.error("[mcp] Error getting next task:", result.content);


### PR DESCRIPTION
The per-workspace MCP server (v0.3.6, PR #217) merged getNextTask and getTaskMessages into a single getTask tool. Calling getTask with no taskId reproduces the old getNextTask behavior: dequeue the next not-started task. Update the task-poller call site and tests.