### PR TITLE
fix: prevent gateway crash on network disconnect (#18)

### DIFF
--- a/src/__tests__/acpClient.test.ts
+++ b/src/__tests__/acpClient.test.ts
@@ -50,6 +50,34 @@ describe("AgentRQACPClient", () => {
       expect((response.outcome as any).optionId).toBe("opt-1");
     });
 
+    it("should cancel (not throw) when sendNotification rejects, e.g. on network outage", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      mcpBridge.sendNotification.mockRejectedValue(
+        new Error("MCP not connected after 10s timeout"),
+      );
+
+      const params = {
+        toolCall: {
+          toolCallId: "req-123",
+          title: "Test Tool",
+          rawInput: { foo: "bar" },
+        },
+        options: [
+          { optionId: "opt-1", kind: "allow", name: "Allow Once" },
+          { optionId: "opt-2", kind: "deny", name: "Deny" },
+        ],
+      } as any;
+
+      // Must resolve with a cancelled outcome rather than reject — a rejection
+      // here would surface as an unhandled rejection and crash the gateway.
+      const response = await client.requestPermission(params);
+      expect(response.outcome.outcome).toBe("cancelled");
+      // It must not register a verdict listener it can never clean up.
+      expect(mcpBridge.on).not.toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+
     it("should include task_id in the payload when available", async () => {
       const getTaskId = vi.fn().mockReturnValue("task-123");
       const clientWithTaskId = new AgentRQACPClient(mcpBridge as unknown as MCPBridge, getTaskId);

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -16,6 +16,7 @@ vi.mock("node:child_process", () => {
       stdin: new Writable({ write(chunk, encoding, callback) { callback(); } }),
       stdout: new Readable({ read() { this.push(null); } }),
       kill: vi.fn(),
+      on: vi.fn(),
     }),
   };
 });

--- a/src/acpClient.ts
+++ b/src/acpClient.ts
@@ -85,10 +85,23 @@ export class AgentRQACPClient implements acp.Client {
     console.error(`[acp] Sending permission request notification:`, JSON.stringify(payload, null, 2));
 
     // 1. Forward the permission request to the MCP server as a notification.
-    await this.mcpBridge.sendNotification(
-      "notifications/claude/channel/permission_request",
-      payload
-    );
+    //    If the MCP transport is down (e.g. network outage), sendNotification
+    //    rejects. Swallow it here so the rejection doesn't bubble up as an
+    //    unhandled promise rejection and crash the process — instead cancel
+    //    this permission request and let the transport reconnect in the
+    //    background. The agent receives a clean "cancelled" outcome.
+    try {
+      await this.mcpBridge.sendNotification(
+        "notifications/claude/channel/permission_request",
+        payload
+      );
+    } catch (err) {
+      console.error(
+        `[acp] Failed to forward permission request ${requestId} (cancelling):`,
+        err
+      );
+      return { outcome: { outcome: "cancelled" } };
+    }
 
     // 2. Wait for the verdict from the MCP server
     console.error(`⌛ Waiting for human approval in the agentrq dashboard...`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,25 @@ export async function getOrCreateSession(
     env: { ...process.env, ...agentrqConfig.env },
   });
 
+  // Guard against unhandled child-process failures. Without these listeners a
+  // crashed agent (e.g. on network loss) leaves a broken stdin pipe; the next
+  // write raises EPIPE as an uncaught error and takes the gateway down with it.
+  agentProcess.on("error", (err: Error) => {
+    console.error(`[acp] Agent process error for task ${key}:`, err.message);
+    activeSessions.delete(key);
+  });
+  agentProcess.on("exit", (code: number | null, signal: string | null) => {
+    console.error(
+      `[acp] Agent process for task ${key} exited (code=${code}, signal=${signal})`,
+    );
+    activeSessions.delete(key);
+  });
+  // stdin can emit EPIPE when the child dies mid-write; swallow it so it
+  // doesn't surface as an uncaught exception.
+  agentProcess.stdin?.on("error", (err: Error) => {
+    console.error(`[acp] Agent stdin error for task ${key}:`, err.message);
+  });
+
   const input = Writable.toWeb(agentProcess.stdin!);
   const output = Readable.toWeb(
     agentProcess.stdout!,
@@ -426,6 +445,19 @@ export async function checkForNextTask(
 }
 
 if (process.env.NODE_ENV !== "test") {
+  // Keep the gateway alive across transient failures. The MCP transport has its
+  // own reconnect logic (mcpClient.ts), so a stray rejected promise or async
+  // error from a dropped connection should be logged, not fatal. Without these
+  // nets, Node terminates the process on the first unhandled rejection.
+  process.on("unhandledRejection", (reason) => {
+    console.error("[acp-gateway] Unhandled promise rejection (continuing):", reason);
+  });
+  process.on("uncaughtException", (err) => {
+    console.error("[acp-gateway] Uncaught exception (continuing):", err);
+  });
+
+  // A rejection from main() itself means startup failed before the bridge was
+  // established — that is genuinely fatal, so exit.
   main().catch((err) => {
     console.error("[fatal]", err);
     process.exit(1);


### PR DESCRIPTION
Three unhandled failure paths terminated the gateway process on network loss instead of letting the MCP transport reconnect:

1. requestPermission (acpClient.ts) awaited sendNotification with no try-catch; ensureConnected throws "MCP not connected after 10s timeout" during an outage, rejecting unhandled. Now wrapped: on failure we log and return a "cancelled" outcome so the agent gets a clean response and the process survives.

2. The spawned agent subprocess had no error/exit listeners; a crashed child left a broken stdin pipe and the next write raised EPIPE as an uncaught error. Now we attach error/exit handlers (cleaning up activeSessions) and guard stdin against EPIPE.

3. No process-level safety nets existed, so under Node's default unhandled-rejections=throw a single stray rejection killed the gateway. Added unhandledRejection/uncaughtException handlers that log and continue, letting the existing transport reconnect logic recover. main()'s own rejection still exits, since that means startup failed.

Adds a regression test asserting requestPermission resolves with a cancelled outcome (rather than rejecting) when sendNotification fails.

closes #18 