### PR TITLE
chore: bump minor version to 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install -g @agentrq/acp-gateway
 
 ## Current Version
 
-`0.1.26`
+`0.2.0`
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.1.27",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentrq/acp-gateway",
-      "version": "0.1.27",
+      "version": "0.2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.4.0",
         "@modelcontextprotocol/sdk": "^1.30.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.1.27",
+  "version": "0.2.0",
   "description": "ACP+MCP bridge CLI for agentrq workspaces",
   "type": "module",
   "publishConfig": {

--- a/src/mcpClient.ts
+++ b/src/mcpClient.ts
@@ -84,7 +84,7 @@ export class MCPBridge extends EventEmitter {
     this.client = new Client(
       {
         name: "acp-gateway",
-        version: "0.1.26",
+        version: "0.2.0",
       },
       {
         capabilities: {},


### PR DESCRIPTION
## Summary
- Pulled latest main (includes the dependency update and ACP elicitation delegation work merged earlier today) and bumped the minor version: 0.1.27 → 0.2.0 (`npm version minor`).
- Synced the two other places that track the version out-of-band: README.md's "Current Version" section and the MCP client identity string in src/mcpClient.ts (both had drifted to 0.1.26 during the last bump).

## Test plan
- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm test` (87/87 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)