### PR TITLE
ci: switch npm publish to trusted publishing (OIDC), drop NPM_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,19 +17,24 @@ jobs:
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
-      
+
+      # Trusted publishing (OIDC) requires npm CLI >= 11.5.1; Node 20 ships an
+      # older bundled npm, so upgrade it before the publish step runs.
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Run typecheck
         run: npm run typecheck
-      
+
       - name: Run tests
         run: npm test
-      
+
       - name: Build
         run: npm run build
-      
+
       - name: Publish to npm
         run: |
           PACKAGE_NAME=$(node -p "require('./package.json').name")
@@ -39,5 +44,3 @@ jobs:
           else
             npm publish --provenance --access public
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Switches `.github/workflows/publish.yml` to npm's [trusted publishing](https://docs.npmjs.com/trusted-publishers/) feature — auth now happens via the job's existing `id-token: write` OIDC permission instead of the `NODE_AUTH_TOKEN`/`NPM_TOKEN` secret, which is dropped from the workflow entirely.
- Adds an `npm install -g npm@latest` step before publishing, since trusted publishing requires npm CLI >= 11.5.1 and Node 20 (this workflow's runtime) ships an older bundled npm.

## Required before this actually works
This package must be registered as a trusted publisher on npmjs.com first (npm won't accept OIDC-authenticated publishes otherwise): go to `https://www.npmjs.com/package/@agentrq/acp-gateway/access` → Trusted Publisher → GitHub Actions, and set:
- Organization or user: `agentrq`
- Repository: `acp-gateway`
- Workflow filename: `publish.yml`
- Environment name: (leave blank — this workflow doesn't use one)

Once that's confirmed working (e.g. a tag push publishes successfully), the `NPM_TOKEN` repo secret can be deleted from GitHub — nothing in the workflow references it anymore after this change.

## Test plan
- [x] Workflow YAML change only — no application code touched, so `npm test`/build/typecheck are unaffected (still run 87/87 as before).
- [ ] Configure trusted publisher on npmjs.com (manual, requires npm account access — not something I can do from here)
- [ ] Verify the next tag push publishes successfully without `NPM_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)