### PR TITLE
ci: use latest Node LTS in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'
 
       # Trusted publishing (OIDC) requires npm CLI >= 11.5.1; Node 20 ships an


### PR DESCRIPTION
## Summary
Follow-up to #24: the publish workflow's `npm install -g npm@latest` step failed with `EBADENGINE` — it resolved to npm 12.0.2, which requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`, newer than the Node 20 this workflow pinned. Switches to `lts/*` so the runtime tracks whatever npm "latest" actually needs.

## Test plan
- [x] CI-only change, no application code touched.