### PR TITLE
ci: bump actions/checkout and actions/setup-node to v7

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Summary
The last publish run (v0.2.0) surfaced a GitHub Actions deprecation warning: Node 20 runners are being retired, and `actions/checkout@v4`/`actions/setup-node@v4` were being force-run on Node 24 to compensate. Bumps both to their current major (v7), which targets a supported Node version natively — no more forced compatibility shim, no functional change to the workflow otherwise.

## Test plan
- [x] CI-only change, no application code touched.
- [ ] Confirm the next tag push runs clean without the deprecation warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)