### PR TITLE
fix: never let a permission verdict bypass agentrq approval

### DIFF
--- a/src/__tests__/acpClient.test.ts
+++ b/src/__tests__/acpClient.test.ts
@@ -258,6 +258,138 @@ describe("AgentRQACPClient", () => {
       expect((response.outcome as any).optionId).toBe("opt-1");
     });
 
+    it("should match spec-compliant reject_once/reject_always kinds on deny (not just a literal 'deny' kind prefix)", async () => {
+      const params = {
+        toolCall: { toolCallId: "req-123" },
+        options: [
+          { optionId: "opt-1", kind: "allow_once", name: "Allow Once" },
+          { optionId: "opt-2", kind: "reject_once", name: "Reject Once" },
+        ],
+      } as any;
+
+      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
+        if (event === "verdict") {
+          setTimeout(
+            () => handler({ requestId: "req-123", behavior: "deny" }),
+            10,
+          );
+        }
+      });
+
+      const response = await client.requestPermission(params);
+      // A spec-compliant "reject_once" kind must never be missed and fall
+      // through to the first (allow) option — that would silently approve a
+      // tool call the human explicitly denied.
+      expect((response.outcome as any).optionId).toBe("opt-2");
+    });
+
+    it("should never resolve a deny verdict to an allow-kind option, even with no matching option", async () => {
+      const params = {
+        toolCall: { toolCallId: "req-123" },
+        options: [
+          { optionId: "opt-1", kind: "allow_once", name: "Proceed" },
+          { optionId: "opt-2", kind: "other", name: "Skip" },
+        ],
+      } as any;
+
+      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
+        if (event === "verdict") {
+          setTimeout(
+            () => handler({ requestId: "req-123", behavior: "deny" }),
+            10,
+          );
+        }
+      });
+
+      const response = await client.requestPermission(params);
+      expect((response.outcome as any).optionId).toBe("opt-2");
+    });
+
+    it("should cancel a deny verdict rather than select an allow option when every option is allow-kind", async () => {
+      const params = {
+        toolCall: { toolCallId: "req-123" },
+        options: [{ optionId: "opt-1", kind: "allow_once", name: "Proceed" }],
+      } as any;
+
+      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
+        if (event === "verdict") {
+          setTimeout(
+            () => handler({ requestId: "req-123", behavior: "deny" }),
+            10,
+          );
+        }
+      });
+
+      const response = await client.requestPermission(params);
+      expect(response.outcome.outcome).toBe("cancelled");
+    });
+
+    it("should select the once option on allow, never the always option, so future calls still require agentrq approval", async () => {
+      const params = {
+        toolCall: { toolCallId: "req-123" },
+        options: [
+          { optionId: "opt-always", kind: "allow_always", name: "Always Allow" },
+          { optionId: "opt-once", kind: "allow_once", name: "Allow Once" },
+        ],
+      } as any;
+
+      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
+        if (event === "verdict") {
+          setTimeout(
+            () => handler({ requestId: "req-123", behavior: "allow" }),
+            10,
+          );
+        }
+      });
+
+      const response = await client.requestPermission(params);
+      // Selecting "allow_always" would make the spawned agent remember this
+      // decision and stop asking for matching future tool calls, bypassing
+      // agentrq entirely for those. Must always pick the once-only variant.
+      expect((response.outcome as any).optionId).toBe("opt-once");
+    });
+
+    it("should select the once option on deny, never the always option", async () => {
+      const params = {
+        toolCall: { toolCallId: "req-123" },
+        options: [
+          { optionId: "opt-always", kind: "reject_always", name: "Always Reject" },
+          { optionId: "opt-once", kind: "reject_once", name: "Reject Once" },
+        ],
+      } as any;
+
+      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
+        if (event === "verdict") {
+          setTimeout(
+            () => handler({ requestId: "req-123", behavior: "deny" }),
+            10,
+          );
+        }
+      });
+
+      const response = await client.requestPermission(params);
+      expect((response.outcome as any).optionId).toBe("opt-once");
+    });
+
+    it("should cancel an allow verdict rather than select an always-kind option when no once option exists", async () => {
+      const params = {
+        toolCall: { toolCallId: "req-123" },
+        options: [{ optionId: "opt-always", kind: "allow_always", name: "Always Allow" }],
+      } as any;
+
+      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
+        if (event === "verdict") {
+          setTimeout(
+            () => handler({ requestId: "req-123", behavior: "allow" }),
+            10,
+          );
+        }
+      });
+
+      const response = await client.requestPermission(params);
+      expect(response.outcome.outcome).toBe("cancelled");
+    });
+
     it("should fall back to first option if no match", async () => {
       const params = {
         toolCall: { toolCallId: "req-123" },

--- a/src/acpClient.ts
+++ b/src/acpClient.ts
@@ -114,24 +114,55 @@ export class AgentRQACPClient implements acp.Client {
           
           console.error(`✅ Permission verdict received: ${data.behavior}`);
 
-          // Map "allow"/"deny" to the correct ACP option
-          // ACP options usually include "allow_once", "allow_always", etc.
-          const verdictMatch = data.behavior === "allow" ? "allow" : "deny";
-          const option = params.options.find(o => 
-            o.kind.startsWith(verdictMatch) ||
-            o.name.toLowerCase().includes(verdictMatch) || 
-            (verdictMatch === "allow" && (o.name.toLowerCase().includes("yes") || o.name.toLowerCase().includes("approve")))
+          // A verdict from agentrq covers exactly one tool call. Never select
+          // a "persistent" option (ACP's "allow_always"/"reject_always" kinds,
+          // or an equivalent "remember"/"don't ask again" option by name) —
+          // picking one would make the *spawned agent* remember the decision
+          // and stop sending requestPermission for matching future tool
+          // calls, so those calls would never reach agentrq again. Every
+          // subsequent call must still be forwarded and re-approved there.
+          const isPersistent = (o: acp.PermissionOption) =>
+            /always|remember|don'?t ask/i.test(o.kind) || /always|remember|don'?t ask/i.test(o.name);
+          const onceOptions = params.options.filter(o => !isPersistent(o));
+
+          // Map "allow"/"deny" to the correct ACP option. Per the ACP spec,
+          // PermissionOptionKind is one of "allow_once" | "allow_always" |
+          // "reject_once" | "reject_always" — there is no "deny_*" kind, so a
+          // deny verdict must match on "reject" to find a spec-compliant option.
+          const isAllow = data.behavior === "allow";
+          const option = onceOptions.find(o => {
+            const name = o.name.toLowerCase();
+            return isAllow
+              ? o.kind.startsWith("allow") || name.includes("allow") || name.includes("yes") || name.includes("approve")
+              : o.kind.startsWith("reject") || name.includes("deny") || name.includes("reject") || name.includes("no");
+          });
+
+          // Falling back to onceOptions[0] unconditionally is unsafe for a
+          // deny verdict: ACP conventionally lists allow options first, so an
+          // unmatched deny could silently resolve to an allow option and
+          // approve a tool call the human explicitly denied. Only ever fall
+          // back to a non-persistent option that is not itself an allow-kind;
+          // if no safe option exists at all (e.g. only "always" options were
+          // offered), cancel instead of guessing.
+          let outcome: acp.RequestPermissionOutcome;
+          if (option) {
+            outcome = { outcome: "selected", optionId: option.optionId };
+          } else if (isAllow) {
+            outcome = onceOptions[0]
+              ? { outcome: "selected", optionId: onceOptions[0].optionId }
+              : { outcome: "cancelled" };
+          } else {
+            const safeFallback = onceOptions.find(o => !o.kind.startsWith("allow"));
+            outcome = safeFallback
+              ? { outcome: "selected", optionId: safeFallback.optionId }
+              : { outcome: "cancelled" };
+          }
+
+          console.error(
+            `[acp] Selected permission option: ${"optionId" in outcome ? outcome.optionId : "cancelled"} (${option?.name ?? "default"})`
           );
 
-          const optionId = option?.optionId ?? params.options[0].optionId;
-          console.error(`[acp] Selected permission option: ${optionId} (${option?.name ?? "default"})`);
-
-          resolve({
-            outcome: {
-              outcome: "selected",
-              optionId: optionId,
-            },
-          });
+          resolve({ outcome });
         }
       };
 


### PR DESCRIPTION
## Summary
- `requestPermission`'s verdict handler matched a deny verdict against `kind.startsWith("deny")`, but ACP's real `PermissionOptionKind` values are `allow_once | allow_always | reject_once | reject_always` — there's no `deny_*` kind. An unmatched deny fell back to `options[0]` (conventionally the allow option), so an explicit human denial could silently resolve to an approval.
- The matcher could also select an `_always` option. Picking one causes the spawned ACP agent to remember the decision and stop sending `requestPermission` for matching tool calls for the rest of the session — so subsequent calls of that kind would bypass agentrq entirely instead of being individually approved.
- Fixed both: deny now matches `reject_*` kinds, every verdict filters out any "always"/"remember"/"don't ask again" option before matching (so it only ever resolves to a single-call decision), and a deny verdict can never fall back to an allow-kind option — it cancels instead of guessing when no safe option exists.

## Test plan
- [x] `npx vitest run` — 93/93 passing (6 new regression tests covering spec-compliant reject kinds, deny never resolving to allow, deny/allow never resolving to an `_always` option, and cancelling when no safe option exists)
- [x] `npx tsc --noEmit`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)