### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install -g @agentrq/acp-gateway
 
 ## Current Version
 
-`0.2.0`
+`0.2.1`
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentrq/acp-gateway",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.4.0",
         "@modelcontextprotocol/sdk": "^1.30.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "ACP+MCP bridge CLI for agentrq workspaces",
   "type": "module",
   "publishConfig": {

--- a/src/mcpClient.ts
+++ b/src/mcpClient.ts
@@ -84,7 +84,7 @@ export class MCPBridge extends EventEmitter {
     this.client = new Client(
       {
         name: "acp-gateway",
-        version: "0.2.0",
+        version: "0.2.1",
       },
       {
         capabilities: {},


### PR DESCRIPTION
## Summary
- Patch version bump: `0.2.0` -> `0.2.1` in `package.json`, `package-lock.json`, the `README.md` "Current Version" line, and the MCP `Client` identity version reported in `src/mcpClient.ts`.

## Test plan
- [x] `npx vitest run` — 93/93 passing (no behavior changed; no new lines requiring new coverage — this is a version-string-only change)
- [x] `npx tsc --noEmit`
- [x] `npm run build` (confirms build now reports `0.2.1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)