### PR TITLE
fix: delegate tool call approvals to agentrq by forcing a human-approval session mode

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -7,6 +7,8 @@ import {
   TaskQueue,
   getOrCreateSession,
   activeSessions,
+  pickHumanApprovalMode,
+  enforceHumanApprovalMode,
 } from "../index.js";
 import type { McpServerConfig } from "../config.js";
 
@@ -427,6 +429,168 @@ describe("index", () => {
             elicitation: { form: {}, url: {} },
           }),
         }),
+      );
+    });
+  });
+
+  describe("pickHumanApprovalMode", () => {
+    // The real modes codex-acp advertises. Its default is "agent", whose
+    // reviewer is an automated Guardian Review that approves on the human's
+    // behalf — so tool calls never reach agentrq.
+    const codexModes: any = {
+      currentModeId: "agent",
+      availableModes: [
+        { id: "read-only", name: "Ask for approval", _meta: { kind: "standard" } },
+        { id: "agent", name: "Approve for me", _meta: { kind: "auto_review" } },
+        { id: "agent-full-access", name: "Full access", _meta: { kind: "full_access" } },
+      ],
+    };
+
+    it("should pick the human-approval mode over auto-reviewing and full-access modes", () => {
+      expect(pickHumanApprovalMode(codexModes)).toBe("read-only");
+    });
+
+    it("should return undefined when the agent advertises no modes", () => {
+      expect(pickHumanApprovalMode(undefined)).toBeUndefined();
+      expect(pickHumanApprovalMode(null)).toBeUndefined();
+      expect(pickHumanApprovalMode({ currentModeId: "x", availableModes: [] } as any)).toBeUndefined();
+    });
+
+    it("should return undefined when every available mode auto-approves", () => {
+      const modes: any = {
+        currentModeId: "agent",
+        availableModes: [
+          { id: "agent", name: "Approve for me", _meta: { kind: "auto_review" } },
+          { id: "yolo", name: "Never ask", _meta: { kind: "full_access" } },
+        ],
+      };
+      expect(pickHumanApprovalMode(modes)).toBeUndefined();
+    });
+
+    it("should fall back to the first non-auto-approving mode when none names approval", () => {
+      const modes: any = {
+        currentModeId: "fast",
+        availableModes: [
+          { id: "fast", name: "Full access", _meta: { kind: "full_access" } },
+          { id: "careful", name: "Careful" },
+          { id: "other", name: "Other" },
+        ],
+      };
+      expect(pickHumanApprovalMode(modes)).toBe("careful");
+    });
+
+    it("should tolerate modes without _meta or with a non-string kind", () => {
+      const modes: any = {
+        currentModeId: "a",
+        availableModes: [
+          { id: "a", name: "Full access" },
+          { id: "b", name: "Ask first", _meta: { kind: 42 } },
+        ],
+      };
+      expect(pickHumanApprovalMode(modes)).toBe("b");
+    });
+  });
+
+  describe("enforceHumanApprovalMode", () => {
+    let consoleSpy: any;
+
+    beforeEach(() => {
+      consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    it("should switch out of an auto-approving default mode", async () => {
+      const connection: any = { setSessionMode: vi.fn().mockResolvedValue({}) };
+      const sessionResult: any = {
+        sessionId: "sess-1",
+        modes: {
+          currentModeId: "agent",
+          availableModes: [
+            { id: "read-only", name: "Ask for approval", _meta: { kind: "standard" } },
+            { id: "agent", name: "Approve for me", _meta: { kind: "auto_review" } },
+          ],
+        },
+      };
+
+      await enforceHumanApprovalMode(connection, sessionResult);
+
+      expect(connection.setSessionMode).toHaveBeenCalledWith({
+        sessionId: "sess-1",
+        modeId: "read-only",
+      });
+    });
+
+    it("should do nothing when the agent advertises no modes", async () => {
+      const connection: any = { setSessionMode: vi.fn() };
+
+      await enforceHumanApprovalMode(connection, { sessionId: "sess-1" } as any);
+      await enforceHumanApprovalMode(connection, {
+        sessionId: "sess-1",
+        modes: { currentModeId: "x", availableModes: [] },
+      } as any);
+
+      expect(connection.setSessionMode).not.toHaveBeenCalled();
+    });
+
+    it("should not switch when already in a human-approval mode", async () => {
+      const connection: any = { setSessionMode: vi.fn() };
+      const sessionResult: any = {
+        sessionId: "sess-1",
+        modes: {
+          currentModeId: "read-only",
+          availableModes: [
+            { id: "read-only", name: "Ask for approval", _meta: { kind: "standard" } },
+            { id: "agent", name: "Approve for me", _meta: { kind: "auto_review" } },
+          ],
+        },
+      };
+
+      await enforceHumanApprovalMode(connection, sessionResult);
+
+      expect(connection.setSessionMode).not.toHaveBeenCalled();
+    });
+
+    it("should warn and not switch when every mode auto-approves", async () => {
+      const connection: any = { setSessionMode: vi.fn() };
+      const sessionResult: any = {
+        sessionId: "sess-1",
+        modes: {
+          currentModeId: "agent",
+          availableModes: [
+            { id: "agent", name: "Approve for me", _meta: { kind: "auto_review" } },
+            { id: "full", name: "Full access", _meta: { kind: "full_access" } },
+          ],
+        },
+      };
+
+      await enforceHumanApprovalMode(connection, sessionResult);
+
+      expect(connection.setSessionMode).not.toHaveBeenCalled();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("no mode that defers approvals to the human"),
+      );
+    });
+
+    it("should log and not throw when setSessionMode fails", async () => {
+      const connection: any = {
+        setSessionMode: vi.fn().mockRejectedValue(new Error("unsupported")),
+      };
+      const sessionResult: any = {
+        sessionId: "sess-1",
+        modes: {
+          currentModeId: "agent",
+          availableModes: [
+            { id: "read-only", name: "Ask for approval", _meta: { kind: "standard" } },
+            { id: "agent", name: "Approve for me", _meta: { kind: "auto_review" } },
+          ],
+        },
+      };
+
+      await expect(
+        enforceHumanApprovalMode(connection, sessionResult),
+      ).resolves.toBeUndefined();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to set session mode"),
+        expect.any(Error),
       );
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,6 +131,8 @@ export async function getOrCreateSession(
   const sessionResult = await connection.newSession(newSessionParams);
   console.error(`[acp] Created session ${sessionResult.sessionId} for task ${key}`);
 
+  await enforceHumanApprovalMode(connection, sessionResult);
+
   const sessionInfo: AgentSession = {
     process: agentProcess,
     connection,
@@ -144,6 +146,78 @@ export async function getOrCreateSession(
 type AcpNewSessionParams = Parameters<
   acp.ClientSideConnection["newSession"]
 >[0];
+
+// Modes that approve tool calls without asking the user. codex-acp, for
+// example, defaults to an "agent" mode whose reviewer is "auto_review" — an
+// automated Guardian Review that approves on the human's behalf — and also
+// offers an "agent-full-access" mode that never asks at all.
+const AUTO_APPROVING_MODE = /auto|full[\s_-]?access|danger|bypass|yolo|never|always/i;
+// Modes that defer the decision to the human.
+const HUMAN_APPROVAL_MODE = /ask|approval|approve|manual|prompt|review|read[\s_-]?only/i;
+
+function describeMode(mode: acp.SessionMode): string {
+  const kind = (mode._meta as { kind?: unknown } | null | undefined)?.kind;
+  return `${mode.id} ${mode.name} ${typeof kind === "string" ? kind : ""}`;
+}
+
+/**
+ * Picks the session mode that routes every tool-call approval to the human.
+ *
+ * Agents may offer modes that approve on the user's behalf and commonly
+ * default to one. In such a mode the agent never sends a permission request,
+ * so tool calls — including destructive ones — execute without ever reaching
+ * agentrq. Returns the id of a mode that defers to the human, or undefined if
+ * the agent offers none.
+ */
+export function pickHumanApprovalMode(
+  modes: acp.SessionModeState | null | undefined,
+): string | undefined {
+  const available = modes?.availableModes;
+  if (!available?.length) return undefined;
+
+  const candidates = available.filter((m) => !AUTO_APPROVING_MODE.test(describeMode(m)));
+  const chosen =
+    candidates.find((m) => HUMAN_APPROVAL_MODE.test(describeMode(m))) ?? candidates[0];
+  return chosen?.id;
+}
+
+/**
+ * Switches a freshly created session into a mode that requires human approval,
+ * so that every non-agentrq tool call reaches the agentrq dashboard rather than
+ * being auto-approved inside the agent.
+ */
+export async function enforceHumanApprovalMode(
+  connection: acp.ClientSideConnection,
+  sessionResult: { sessionId: string; modes?: acp.SessionModeState | null },
+): Promise<void> {
+  const modes = sessionResult.modes;
+  // Agents that expose no modes have nothing to switch; they either always ask
+  // or their policy is out of the gateway's reach.
+  if (!modes?.availableModes?.length) return;
+
+  const modeId = pickHumanApprovalMode(modes);
+  if (!modeId) {
+    console.error(
+      `[acp] ⚠️  Agent offers no mode that defers approvals to the human ` +
+        `(available: ${modes.availableModes.map((m) => m.id).join(", ")}). ` +
+        `Tool calls may execute without agentrq approval.`,
+    );
+    return;
+  }
+  if (modeId === modes.currentModeId) return;
+
+  try {
+    await connection.setSessionMode({ sessionId: sessionResult.sessionId, modeId });
+    console.error(
+      `[acp] Session mode set to "${modeId}" (was "${modes.currentModeId}") so tool calls require agentrq approval`,
+    );
+  } catch (err) {
+    console.error(
+      `[acp] ⚠️  Failed to set session mode to "${modeId}" — tool calls may execute without agentrq approval:`,
+      err,
+    );
+  }
+}
 
 export function createAcpSessionSwitcher(
   connection: acp.ClientSideConnection,


### PR DESCRIPTION
**What changed**

The gateway now checks which operating modes the coding agent offers when a session starts, and puts it into one that asks a human before running tool calls instead of accepting whatever the agent defaults to.

**Why changed**

The agent was defaulting to a mode where an automated reviewer approved actions on the human's behalf, so it never asked for permission at all — destructive commands ran without any approval request ever appearing in agentrq. Approvals are now actually delegated to agentrq as intended.

**Test coverage report**

- New lines introduced: **100%** (statements 26/26, branches 12/12, functions 6/6)
- Total coverage impact — all four metrics improved:
  | Metric | Before | After |
  |---|---|---|
  | Statements | 78.79% | 80.00% |
  | Branches | 78.66% | 79.68% |
  | Functions | 67.94% | 70.23% |
  | Lines | 79.53% | 80.53% |
- Suite: 103/103 passing (10 new tests), `tsc --noEmit` and `npm run build` clean.

**Other reports**

Agents advertising no modes are left untouched. If an agent offers *only* auto-approving modes, the gateway logs a prominent warning rather than silently proceeding without approval routing, and a failed mode switch is logged without crashing the session.

**TaskID:** 0hu7dBKdyD3

🤖 Generated with [Claude Code](https://claude.com/claude-code)