### PR TITLE
fix: identify MCP tool calls whose permission request omits the tool name

### DIFF
--- a/src/__tests__/acpClient.test.ts
+++ b/src/__tests__/acpClient.test.ts
@@ -192,6 +192,296 @@ describe("AgentRQACPClient", () => {
       consoleSpy.mockRestore();
     });
 
+    // codex-acp emits a `tool_call` session update naming the MCP tool, then
+    // requests permission for that same toolCallId with no title and no
+    // rawInput. Without correlating the two, agentrq's own calls reach the
+    // human as "Unknown Tool" instead of being auto-allowed.
+    it("should auto-allow an agentrq MCP call whose permission request carries no title", async () => {
+      await client.sessionUpdate({
+        sessionId: "sess-1",
+        update: {
+          sessionUpdate: "tool_call",
+          toolCallId: "call_QDSxAGK3Qagv",
+          title: "mcp.agentrq-0cHiaZsOGMj.updateTaskStatus",
+          status: "pending",
+          rawInput: { server: "agentrq-0cHiaZsOGMj", tool: "updateTaskStatus", arguments: {} },
+        },
+      } as any);
+
+      const params = {
+        sessionId: "sess-1",
+        toolCall: { toolCallId: "call_QDSxAGK3Qagv", kind: "execute", status: "pending" },
+        options: [
+          { optionId: "opt-1", kind: "allow_once", name: "Allow" },
+          { optionId: "opt-2", kind: "reject_once", name: "Reject" },
+        ],
+      } as any;
+
+      const response = await client.requestPermission(params);
+
+      expect(mcpBridge.sendNotification).not.toHaveBeenCalled();
+      expect((response.outcome as any).optionId).toBe("opt-1");
+    });
+
+    it("should recover the title and input from an earlier tool_call_update", async () => {
+      await client.sessionUpdate({
+        sessionId: "sess-1",
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId: "call_abc",
+          title: "mcp.other-server.doThing",
+          status: "pending",
+          rawInput: { server: "other-server", tool: "doThing" },
+        },
+      } as any);
+
+      const params = {
+        sessionId: "sess-1",
+        toolCall: { toolCallId: "call_abc", kind: "execute", status: "pending" },
+        options: [
+          { optionId: "opt-1", kind: "allow_once", name: "Allow" },
+          { optionId: "opt-2", kind: "reject_once", name: "Reject" },
+        ],
+      } as any;
+
+      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
+        if (event === "verdict") {
+          setTimeout(() => handler({ requestId: "call_abc", behavior: "allow" }), 10);
+        }
+      });
+
+      await client.requestPermission(params);
+
+      // A non-agentrq tool still goes to the human, but now with a meaningful
+      // name and input rather than "Unknown Tool" / "{}".
+      expect(mcpBridge.sendNotification).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          tool_name: "mcp.other-server.doThing",
+          input_preview: JSON.stringify({ server: "other-server", tool: "doThing" }),
+        }),
+      );
+    });
+
+    it("should prefer the permission request's own title over the remembered one", async () => {
+      await client.sessionUpdate({
+        sessionId: "sess-1",
+        update: {
+          sessionUpdate: "tool_call",
+          toolCallId: "call_cmd",
+          title: "stale title",
+          status: "pending",
+          rawInput: { command: "stale" },
+        },
+      } as any);
+
+      const params = {
+        sessionId: "sess-1",
+        toolCall: {
+          toolCallId: "call_cmd",
+          title: "Run command",
+          rawInput: { command: "rm index" },
+        },
+        options: [
+          { optionId: "opt-1", kind: "allow_once", name: "Allow" },
+          { optionId: "opt-2", kind: "reject_once", name: "Reject" },
+        ],
+      } as any;
+
+      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
+        if (event === "verdict") {
+          setTimeout(() => handler({ requestId: "call_cmd", behavior: "allow" }), 10);
+        }
+      });
+
+      await client.requestPermission(params);
+
+      expect(mcpBridge.sendNotification).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          tool_name: "Run command",
+          input_preview: JSON.stringify({ command: "rm index" }),
+        }),
+      );
+    });
+
+    it("should still report Unknown Tool when nothing was ever recorded", async () => {
+      const params = {
+        sessionId: "sess-1",
+        toolCall: { toolCallId: "call_unseen", kind: "execute", status: "pending" },
+        options: [
+          { optionId: "opt-1", kind: "allow_once", name: "Allow" },
+          { optionId: "opt-2", kind: "reject_once", name: "Reject" },
+        ],
+      } as any;
+
+      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
+        if (event === "verdict") {
+          setTimeout(() => handler({ requestId: "call_unseen", behavior: "allow" }), 10);
+        }
+      });
+
+      await client.requestPermission(params);
+
+      expect(mcpBridge.sendNotification).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ tool_name: "Unknown Tool", input_preview: "{}" }),
+      );
+    });
+
+    it("should forget a tool call once it has completed, so the map does not grow unbounded", async () => {
+      const record = { sessionId: "sess-1", toolCallId: "call_done", title: "mcp.agentrq-0cHiaZsOGMj.reply" };
+
+      await client.sessionUpdate({
+        sessionId: "sess-1",
+        update: { ...record, sessionUpdate: "tool_call", status: "pending" },
+      } as any);
+      await client.sessionUpdate({
+        sessionId: "sess-1",
+        update: { ...record, sessionUpdate: "tool_call_update", status: "completed" },
+      } as any);
+
+      const params = {
+        sessionId: "sess-1",
+        toolCall: { toolCallId: "call_done", kind: "execute", status: "pending" },
+        options: [
+          { optionId: "opt-1", kind: "allow_once", name: "Allow" },
+          { optionId: "opt-2", kind: "reject_once", name: "Reject" },
+        ],
+      } as any;
+
+      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
+        if (event === "verdict") {
+          setTimeout(() => handler({ requestId: "call_done", behavior: "allow" }), 10);
+        }
+      });
+
+      await client.requestPermission(params);
+
+      // Entry was dropped on completion, so it is no longer auto-allowed by
+      // the remembered title — it goes to the human as an unknown tool.
+      expect(mcpBridge.sendNotification).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ tool_name: "Unknown Tool" }),
+      );
+    });
+
+    it("should not retain details for a consumed permission request", async () => {
+      await client.sessionUpdate({
+        sessionId: "sess-1",
+        update: {
+          sessionUpdate: "tool_call",
+          toolCallId: "call_once",
+          title: "mcp.agentrq-0cHiaZsOGMj.reply",
+          status: "pending",
+        },
+      } as any);
+
+      const params = {
+        sessionId: "sess-1",
+        toolCall: { toolCallId: "call_once", kind: "execute", status: "pending" },
+        options: [
+          { optionId: "opt-1", kind: "allow_once", name: "Allow" },
+          { optionId: "opt-2", kind: "reject_once", name: "Reject" },
+        ],
+      } as any;
+
+      // First request is auto-allowed from the remembered agentrq title.
+      const first = await client.requestPermission(params);
+      expect((first.outcome as any).optionId).toBe("opt-1");
+      expect(mcpBridge.sendNotification).not.toHaveBeenCalled();
+
+      // A replay of the same id no longer resolves, so it reaches the human.
+      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
+        if (event === "verdict") {
+          setTimeout(() => handler({ requestId: "call_once", behavior: "allow" }), 10);
+        }
+      });
+      await client.requestPermission(params);
+      expect(mcpBridge.sendNotification).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ tool_name: "Unknown Tool" }),
+      );
+    });
+
+    // codex-acp follows an accepted MCP approval with a bare
+    // {toolCallId, status: "in_progress"} update carrying no title.
+    it("should retain a known title when a later update omits it", async () => {
+      await client.sessionUpdate({
+        sessionId: "sess-1",
+        update: {
+          sessionUpdate: "tool_call",
+          toolCallId: "call_keep",
+          title: "mcp.agentrq-0cHiaZsOGMj.reply",
+          status: "pending",
+        },
+      } as any);
+      await client.sessionUpdate({
+        sessionId: "sess-1",
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId: "call_keep",
+          status: "in_progress",
+        },
+      } as any);
+
+      const params = {
+        sessionId: "sess-1",
+        toolCall: { toolCallId: "call_keep", kind: "execute", status: "pending" },
+        options: [
+          { optionId: "opt-1", kind: "allow_once", name: "Allow" },
+          { optionId: "opt-2", kind: "reject_once", name: "Reject" },
+        ],
+      } as any;
+
+      const response = await client.requestPermission(params);
+
+      expect(mcpBridge.sendNotification).not.toHaveBeenCalled();
+      expect((response.outcome as any).optionId).toBe("opt-1");
+    });
+
+    it("should record nothing for an update with neither title nor input", async () => {
+      await client.sessionUpdate({
+        sessionId: "sess-1",
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId: "call_bare",
+          status: "in_progress",
+        },
+      } as any);
+
+      const params = {
+        sessionId: "sess-1",
+        toolCall: { toolCallId: "call_bare", kind: "execute", status: "pending" },
+        options: [
+          { optionId: "opt-1", kind: "allow_once", name: "Allow" },
+          { optionId: "opt-2", kind: "reject_once", name: "Reject" },
+        ],
+      } as any;
+
+      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
+        if (event === "verdict") {
+          setTimeout(() => handler({ requestId: "call_bare", behavior: "allow" }), 10);
+        }
+      });
+
+      await client.requestPermission(params);
+
+      expect(mcpBridge.sendNotification).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ tool_name: "Unknown Tool", input_preview: "{}" }),
+      );
+    });
+
+    it("should ignore session updates that carry no tool call id", async () => {
+      await expect(
+        client.sessionUpdate({
+          sessionId: "sess-1",
+          update: { sessionUpdate: "tool_call_update", title: "no id here" },
+        } as any),
+      ).resolves.toBeUndefined();
+    });
+
     it("should match options with 'yes' or 'approve'", async () => {
       const params = {
         toolCall: { toolCallId: "req-123" },

--- a/src/acpClient.ts
+++ b/src/acpClient.ts
@@ -10,10 +10,18 @@ import type { MCPBridge } from "./mcpClient.js";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
+/** Identifies a tool call routed through an agentrq MCP server. */
+const AGENTRQ_TOOL_PATTERN = /agentrq-[a-zA-Z0-9]{11}/;
+
 export class AgentRQACPClient implements acp.Client {
   private replyBuffers = new Map<string, string>();
   // chatId → text sent by the agent via the reply MCP tool (for dedup in flushReply)
   private agentReplies = new Map<string, string>();
+  // toolCallId → details seen on session updates. A `tool_call` update always
+  // carries a title, but the permission request for that same call may omit it
+  // (ACP marks it optional there, and codex-acp sends it bare), which would
+  // otherwise leave us unable to tell an agentrq MCP call from anything else.
+  private toolCallDetails = new Map<string, { title?: string; rawInput?: unknown }>();
 
   constructor(
     private mcpBridge: MCPBridge,
@@ -50,11 +58,15 @@ export class AgentRQACPClient implements acp.Client {
     params: acp.RequestPermissionRequest
   ): Promise<acp.RequestPermissionResponse> {
     const requestId = params.toolCall.toolCallId;
-    const toolTitle = params.toolCall.title ?? "Unknown Tool";
+    // Fall back to what the earlier session update reported for this same tool
+    // call: the permission request itself may carry no title or input.
+    const remembered = this.toolCallDetails.get(requestId);
+    this.toolCallDetails.delete(requestId);
+    const toolTitle = params.toolCall.title ?? remembered?.title ?? "Unknown Tool";
+    const rawInput = params.toolCall.rawInput ?? remembered?.rawInput;
 
     // Auto-allow tool calls that contain the pattern: agentrq-<11 chars a-zA-Z0-9>
-    const agentrqToolPattern = /agentrq-[a-zA-Z0-9]{11}/;
-    if (agentrqToolPattern.test(toolTitle)) {
+    if (AGENTRQ_TOOL_PATTERN.test(toolTitle)) {
       console.error(`\n🔓 ACP Auto-allowing tool call: ${toolTitle} (ID: ${requestId})`);
       const option = params.options.find(o => 
         o.kind.startsWith("allow") ||
@@ -79,7 +91,7 @@ export class AgentRQACPClient implements acp.Client {
       task_id: taskId,
       tool_name: toolTitle,
       description: toolTitle,
-      input_preview: JSON.stringify(params.toolCall.rawInput ?? {}),
+      input_preview: JSON.stringify(rawInput ?? {}),
     };
     console.error(`[acp] Bridge Session ID: ${this.mcpBridge.getSessionId() ?? "unknown"}`);
     console.error(`[acp] Sending permission request notification:`, JSON.stringify(payload, null, 2));
@@ -170,6 +182,37 @@ export class AgentRQACPClient implements acp.Client {
     });
   }
 
+  /**
+   * Records what a tool call is, keyed by its id, so that a permission request
+   * arriving without a title or input can still be identified. ACP requires a
+   * title on the `tool_call` session update but leaves it optional on the
+   * permission request for that same call — codex-acp sends the request bare,
+   * which previously surfaced agentrq's own MCP calls to the human as
+   * "Unknown Tool" instead of being auto-allowed.
+   */
+  private rememberToolCall(update: {
+    toolCallId?: string;
+    title?: string | null;
+    rawInput?: unknown;
+    status?: string | null;
+  }): void {
+    const id = update.toolCallId;
+    if (!id) return;
+
+    // A finished call will never ask for permission, so drop what we kept
+    // rather than growing the map for the lifetime of the session.
+    if (update.status === "completed" || update.status === "failed") {
+      this.toolCallDetails.delete(id);
+      return;
+    }
+
+    const previous = this.toolCallDetails.get(id);
+    const title = update.title ?? previous?.title;
+    const rawInput = update.rawInput ?? previous?.rawInput;
+    if (title === undefined && rawInput === undefined) return;
+    this.toolCallDetails.set(id, { title, rawInput });
+  }
+
   async sessionUpdate(params: acp.SessionNotification): Promise<void> {
     const update = params.update;
 
@@ -181,9 +224,12 @@ export class AgentRQACPClient implements acp.Client {
           this.replyBuffers.set(sid, (this.replyBuffers.get(sid) ?? "") + update.content.text);
         }
         break;
+      case "tool_call_update":
+        this.rememberToolCall(update);
+        break;
       case "tool_call": {
-        const agentrqToolPattern = /agentrq-[a-zA-Z0-9]{11}/;
-        if (update.title && agentrqToolPattern.test(update.title)) {
+        this.rememberToolCall(update);
+        if (update.title && AGENTRQ_TOOL_PATTERN.test(update.title)) {
           // Track completed reply calls so flushReply can skip exact duplicates
           if (
             update.status === "completed" &&


### PR DESCRIPTION
**What changed**

The gateway now remembers what each tool call is as the agent announces it, and uses that to recognise a call when the follow-up approval request arrives without a name or arguments.

**Why changed**

Codex announces a tool call with its full name and arguments but then asks for approval with those fields empty. That meant agentrq's own calls were no longer recognised as its own, so they were pushed to the human as "Unknown Tool" with no detail instead of being approved automatically. Third-party tools now also show a real name and input preview in the dashboard.

**Test coverage report**

- New lines introduced: **100%** (every added statement and branch is exercised)
- Total coverage impact — all four metrics improved:
  | Metric | Before | After |
  |---|---|---|
  | Statements | 80.00% | 80.93% |
  | Branches | 79.68% | 81.41% |
  | Functions | 70.23% | 71.76% |
  | Lines | 80.53% | 81.19% |
- Suite: 112/112 passing (9 new tests), `tsc --noEmit` and `npm run build` clean.

**Other reports**

Root cause verified directly against the agent's published source rather than inferred: it builds the approval request as `{toolCallId, kind, status}` only, reusing the id of the tool call it announced moments earlier — so correlating on that id recovers both the name and the arguments. Remembered entries are discarded once used or once a call finishes, so the lookup table cannot grow for the life of a long-running session.

**TaskID:** 0huDjb1lmMr

🤖 Generated with [Claude Code](https://claude.com/claude-code)