### PR TITLE
chore: bump patch version to 0.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install -g @agentrq/acp-gateway
 
 ## Current Version
 
-`0.2.2`
+`0.2.3`
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentrq/acp-gateway",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.4.0",
         "@modelcontextprotocol/sdk": "^1.30.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "ACP+MCP bridge CLI for agentrq workspaces",
   "type": "module",
   "publishConfig": {

--- a/src/mcpClient.ts
+++ b/src/mcpClient.ts
@@ -84,7 +84,7 @@ export class MCPBridge extends EventEmitter {
     this.client = new Client(
       {
         name: "acp-gateway",
-        version: "0.2.2",
+        version: "0.2.3",
       },
       {
         capabilities: {},


### PR DESCRIPTION
**What changed**

Bumped the patch version from 0.2.2 to 0.2.3, updating every place the version is stated so they stay in sync.

**Why changed**

To release the fix that restores automatic approval of agentrq's own calls under codex, which currently only exists on main and cannot reach anyone running the published package.

**Test coverage report**

- New lines introduced: **100%** — no new executable lines; this is a version-string-only change with no behavioral code.
- Total coverage impact: **none** (unchanged) — statements 80.93%, branches 81.41%, functions 71.76%, lines 81.19%.
- Suite: 112/112 passing, `tsc --noEmit` and `npm run build` clean (build reports 0.2.3).

**Other reports**

Verified no stale references to the previous version remain outside of unrelated third-party lockfile entries.

**TaskID:** 0huEnHoMRrl

🤖 Generated with [Claude Code](https://claude.com/claude-code)