### PR TITLE
feat: log in to ACP agents that require authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,51 @@ acp-gateway -- your-acp-agent --flag1 --flag2
 You can specify gateway options before the `--` separator:
 
 - `--max-concurrency` / `--maxConcurrency` `<number>`: Sets the maximum number of concurrent tasks allowed to prompt the ACP agent at once. Defaults to `2`.
+- `--auth-method <id>`: The authentication method to use when the agent asks for a login. Defaults to picking one automatically.
+- `--list-auth-methods`: Prints the login methods the agent advertises, then exits.
+- `--login [method-id]`: Logs in to the agent, then exits.
+- `--logout`: Ends the agent's authenticated state, then exits (only for agents that support logout).
 
 Example:
 ```bash
 acp-gateway --max-concurrency 4 -- gemini --acp
 ```
+
+### Authentication
+
+Agents that require a login advertise their login methods during the ACP handshake, and refuse to open a
+session until one has been used. `acp-gateway` handles that the same way an editor such as Zed does.
+
+List what an agent offers:
+
+```bash
+acp-gateway --list-auth-methods -- gemini --acp
+```
+
+Log in ahead of time — with no method id, you are asked to pick one:
+
+```bash
+acp-gateway --login -- gemini --acp
+acp-gateway --login oauth-personal -- gemini --acp   # or name the method directly
+```
+
+Log out again:
+
+```bash
+acp-gateway --logout -- gemini --acp
+```
+
+Nothing has to be done up front, though: if an agent refuses the first session because it needs a login,
+`acp-gateway` logs in and retries by itself.
+
+There are two kinds of method:
+
+- **Agent** methods — the agent runs the login itself (a browser flow, an API key it already holds). These
+  need nobody present, so they are chosen first and work in an unattended gateway.
+- **Terminal** methods — the agent's own binary is re-run interactively so you can log in at a TUI.
+  `acp-gateway` only offers to run these when it has a real terminal to hand over.
+
+Credentials are never stored by the gateway; the agent keeps its own, exactly as it does under an editor.
 
 ### Configuration
 
@@ -134,6 +174,7 @@ Example `.mcp.json`:
 | `src/acpClient.ts` | Implements the ACP `Client` interface — routes permission requests, handles session updates, and provides file operations. |
 | `src/mcpClient.ts` | `EventEmitter`-based MCP client with auto-reconnection, notification handling, and tool call dispatch. |
 | `src/config.ts` | Parses `.mcp.json` from the current directory tree up to 3 levels deep. |
+| `src/auth.ts` | ACP authentication — lists the agent's login methods, detects `auth_required`, and runs agent or terminal logins. |
 
 ## Development
 
@@ -156,6 +197,7 @@ npm test
 acp-gateway/
 ├── src/
 │   ├── acpClient.ts      # ACP Client implementation
+│   ├── auth.ts            # ACP authentication (login / logout)
 │   ├── config.ts          # .mcp.json loader
 │   ├── index.ts           # Entry point & orchestrator
 │   ├── mcpClient.ts       # MCP Bridge with auto-reconnect
@@ -169,6 +211,7 @@ acp-gateway/
 - **Auto-reconnection**: The MCP transport auto-reconnects on disconnection with exponential backoff (1s → 30s max).
 - **Notification-driven tasks**: The MCP server pushes task content via `notifications/claude/channel`; `acp-gateway` reacts immediately.
 - **Permission flow**: ACP agent requests permission → `acp-gateway` forwards to MCP server → waits for verdict → resolves the ACP permission.
+- **Authentication**: Login methods come from the `initialize` handshake; an `auth_required` refusal triggers a login and one retry of `newSession`.
 - **File I/O**: `readTextFile` / `writeTextFile` are proxied directly to the filesystem; paths are resolved relative to `process.cwd()`.
 
 ## Contributing

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -1,0 +1,372 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "node:events";
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline/promises";
+import {
+  AUTH_REQUIRED_CODE,
+  authMethodType,
+  describeAuthMethods,
+  isAuthRequiredError,
+  login,
+  logout,
+  pickAuthMethod,
+  promptForAuthMethod,
+  runAuthMethod,
+  runTerminalAuth,
+  supportsLogout,
+} from "../auth.js";
+
+vi.mock("node:child_process", () => ({ spawn: vi.fn() }));
+vi.mock("node:readline/promises", () => ({ createInterface: vi.fn() }));
+
+const spawnMock = vi.mocked(spawn);
+const createInterfaceMock = vi.mocked(createInterface);
+
+const agentMethod: any = {
+  id: "agent-login",
+  name: "Agent login",
+  description: "Sign in through the agent",
+};
+const terminalMethod: any = {
+  type: "terminal",
+  id: "cli-login",
+  name: "CLI login",
+  args: ["auth", "login"],
+  env: { AUTH_MODE: "interactive" },
+};
+
+const launch = { command: "gemini", args: ["--acp"], env: { FROM_CONFIG: "1" } };
+
+/** An `auth_required` refusal as the SDK surfaces it to the caller. */
+function authRequiredError(): Error & { code: number } {
+  return Object.assign(new Error("Authentication required: run login first"), {
+    code: AUTH_REQUIRED_CODE,
+  });
+}
+
+describe("auth", () => {
+  let errorSpy: any;
+  let logSpy: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  describe("authMethodType", () => {
+    it("treats a missing type as the agent-driven default", () => {
+      expect(authMethodType(agentMethod)).toBe("agent");
+      expect(authMethodType({ ...agentMethod, type: "agent" } as any)).toBe("agent");
+    });
+
+    it("recognises terminal methods", () => {
+      expect(authMethodType(terminalMethod)).toBe("terminal");
+    });
+  });
+
+  describe("describeAuthMethods", () => {
+    it("says so when the agent needs no login", () => {
+      expect(describeAuthMethods([])).toMatch(/no authentication methods/);
+      expect(describeAuthMethods(undefined)).toMatch(/no authentication methods/);
+      expect(describeAuthMethods(null)).toMatch(/no authentication methods/);
+    });
+
+    it("numbers the methods and marks terminal ones", () => {
+      const text = describeAuthMethods([agentMethod, terminalMethod]);
+      expect(text).toContain("1. Agent login (agent-login) — Sign in through the agent");
+      expect(text).toContain("2. CLI login (cli-login) [terminal login]");
+    });
+  });
+
+  describe("isAuthRequiredError", () => {
+    it("recognises the protocol's auth_required refusal", () => {
+      expect(isAuthRequiredError(authRequiredError())).toBe(true);
+    });
+
+    it("reads the error out of a nested JSON-RPC envelope", () => {
+      expect(
+        isAuthRequiredError({
+          error: { code: AUTH_REQUIRED_CODE, message: "auth_required" },
+        }),
+      ).toBe(true);
+    });
+
+    it("reads the top level when `error` is not an envelope", () => {
+      expect(
+        isAuthRequiredError({
+          error: "auth_required",
+          code: AUTH_REQUIRED_CODE,
+          message: "Authentication required",
+        }),
+      ).toBe(true);
+    });
+
+    it("ignores other failures that share the -32000 code", () => {
+      expect(
+        isAuthRequiredError(
+          Object.assign(new Error("permission failed"), { code: AUTH_REQUIRED_CODE }),
+        ),
+      ).toBe(false);
+    });
+
+    it("ignores errors with a different code or no shape at all", () => {
+      expect(
+        isAuthRequiredError(Object.assign(new Error("Authentication required"), { code: -32603 })),
+      ).toBe(false);
+      expect(isAuthRequiredError({ code: AUTH_REQUIRED_CODE })).toBe(false);
+      expect(isAuthRequiredError(new Error("Authentication required"))).toBe(false);
+      expect(isAuthRequiredError("nope")).toBe(false);
+      expect(isAuthRequiredError(null)).toBe(false);
+    });
+  });
+
+  describe("pickAuthMethod", () => {
+    it("returns nothing when the agent advertises no methods", () => {
+      expect(pickAuthMethod([])).toBeUndefined();
+      expect(pickAuthMethod(undefined)).toBeUndefined();
+    });
+
+    it("honours an explicitly named method, terminal included", () => {
+      expect(pickAuthMethod([agentMethod, terminalMethod], { preferredId: "cli-login" })).toBe(
+        terminalMethod,
+      );
+    });
+
+    it("returns nothing when the named method is not advertised", () => {
+      expect(pickAuthMethod([agentMethod], { preferredId: "missing" })).toBeUndefined();
+    });
+
+    it("prefers agent-driven methods, which need no human", () => {
+      expect(pickAuthMethod([terminalMethod, agentMethod])).toBe(agentMethod);
+    });
+
+    it("falls back to a terminal method only when a terminal is available", () => {
+      expect(pickAuthMethod([terminalMethod])).toBeUndefined();
+      expect(pickAuthMethod([terminalMethod], { allowTerminal: true })).toBe(terminalMethod);
+    });
+  });
+
+  describe("promptForAuthMethod", () => {
+    it("returns nothing when there is nothing to choose from", async () => {
+      expect(await promptForAuthMethod([], vi.fn())).toBeUndefined();
+    });
+
+    it("does not ask when the agent offers a single method", async () => {
+      const ask = vi.fn();
+      expect(await promptForAuthMethod([agentMethod], ask)).toBe(agentMethod);
+      expect(ask).not.toHaveBeenCalled();
+    });
+
+    it("takes the first method when the user just hits enter", async () => {
+      const ask = vi.fn().mockResolvedValue("  ");
+      expect(await promptForAuthMethod([agentMethod, terminalMethod], ask)).toBe(agentMethod);
+    });
+
+    it("accepts a selection by number", async () => {
+      const ask = vi.fn().mockResolvedValue("2");
+      expect(await promptForAuthMethod([agentMethod, terminalMethod], ask)).toBe(terminalMethod);
+    });
+
+    it("accepts a selection by method id", async () => {
+      const ask = vi.fn().mockResolvedValue("cli-login");
+      expect(await promptForAuthMethod([agentMethod, terminalMethod], ask)).toBe(terminalMethod);
+    });
+
+    it("re-asks after an answer that matches nothing", async () => {
+      const ask = vi.fn().mockResolvedValueOnce("99").mockResolvedValueOnce("1");
+      expect(await promptForAuthMethod([agentMethod, terminalMethod], ask)).toBe(agentMethod);
+      expect(ask).toHaveBeenCalledTimes(2);
+      expect(errorSpy).toHaveBeenCalledWith('[auth] "99" is not one of the listed methods.');
+    });
+
+    it("gives up after three unusable answers", async () => {
+      const ask = vi.fn().mockResolvedValue("nonsense");
+      expect(await promptForAuthMethod([agentMethod, terminalMethod], ask)).toBeUndefined();
+      expect(ask).toHaveBeenCalledTimes(3);
+    });
+
+    it("asks on the terminal when no asker is supplied", async () => {
+      const close = vi.fn();
+      createInterfaceMock.mockReturnValue({
+        question: vi.fn().mockResolvedValue("2"),
+        close,
+      } as any);
+
+      expect(await promptForAuthMethod([agentMethod, terminalMethod])).toBe(terminalMethod);
+      expect(createInterfaceMock).toHaveBeenCalledWith({
+        input: process.stdin,
+        output: process.stderr,
+      });
+      expect(close).toHaveBeenCalled();
+    });
+  });
+
+  describe("runTerminalAuth", () => {
+    it("re-runs the agent invocation with the method's args and env", async () => {
+      const child = new EventEmitter();
+      spawnMock.mockReturnValue(child as any);
+
+      const pending = runTerminalAuth(terminalMethod, launch);
+      child.emit("exit", 0, null);
+      await expect(pending).resolves.toBeUndefined();
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        "gemini",
+        ["--acp", "auth", "login"],
+        expect.objectContaining({
+          stdio: "inherit",
+          env: expect.objectContaining({ FROM_CONFIG: "1", AUTH_MODE: "interactive" }),
+        }),
+      );
+    });
+
+    it("passes no extra args or env when the method declares none", async () => {
+      const child = new EventEmitter();
+      spawnMock.mockReturnValue(child as any);
+
+      const pending = runTerminalAuth({ ...agentMethod, type: "terminal" } as any, {
+        command: "gemini",
+        args: ["--acp"],
+      });
+      child.emit("exit", 0, null);
+      await pending;
+
+      expect(spawnMock).toHaveBeenCalledWith("gemini", ["--acp"], expect.anything());
+    });
+
+    it("fails when the login process exits non-zero", async () => {
+      const child = new EventEmitter();
+      spawnMock.mockReturnValue(child as any);
+
+      const pending = runTerminalAuth(terminalMethod, launch);
+      child.emit("exit", 1, null);
+      await expect(pending).rejects.toThrow(/Terminal login "cli-login" failed \(code=1/);
+    });
+
+    it("fails when the login process cannot start", async () => {
+      const child = new EventEmitter();
+      spawnMock.mockReturnValue(child as any);
+
+      const pending = runTerminalAuth(terminalMethod, launch);
+      child.emit("error", new Error("ENOENT"));
+      await expect(pending).rejects.toThrow(/failed to start: ENOENT/);
+    });
+  });
+
+  describe("runAuthMethod", () => {
+    it("asks the agent to authenticate for agent-driven methods", async () => {
+      const connection = { authenticate: vi.fn().mockResolvedValue({}), logout: vi.fn() };
+      await runAuthMethod(connection, agentMethod, launch);
+      expect(connection.authenticate).toHaveBeenCalledWith({ methodId: "agent-login" });
+    });
+
+    it("never sends a terminal method to authenticate", async () => {
+      const child = new EventEmitter();
+      spawnMock.mockReturnValue(child as any);
+      const connection = { authenticate: vi.fn(), logout: vi.fn() };
+
+      const pending = runAuthMethod(connection, terminalMethod, launch);
+      child.emit("exit", 0, null);
+      await pending;
+
+      expect(connection.authenticate).not.toHaveBeenCalled();
+      expect(spawnMock).toHaveBeenCalled();
+    });
+  });
+
+  describe("login", () => {
+    const connection = () => ({ authenticate: vi.fn().mockResolvedValue({}), logout: vi.fn() });
+
+    it("does nothing when the agent advertises no login", async () => {
+      const conn = connection();
+      expect(await login({ connection: conn, methods: [], launch })).toBeUndefined();
+      expect(conn.authenticate).not.toHaveBeenCalled();
+    });
+
+    it("logs in with the method the user named", async () => {
+      const conn = connection();
+      const used = await login({
+        connection: conn,
+        methods: [agentMethod, { ...agentMethod, id: "other", name: "Other" }],
+        launch,
+        preferredId: "other",
+      });
+      expect(used?.id).toBe("other");
+      expect(conn.authenticate).toHaveBeenCalledWith({ methodId: "other" });
+    });
+
+    it("rejects a method the agent does not advertise", async () => {
+      await expect(
+        login({ connection: connection(), methods: [agentMethod], launch, preferredId: "nope" }),
+      ).rejects.toThrow(/Unknown authentication method "nope"/);
+    });
+
+    it("picks an agent-driven method when running unattended", async () => {
+      const conn = connection();
+      const used = await login({ connection: conn, methods: [terminalMethod, agentMethod], launch });
+      expect(used).toBe(agentMethod);
+    });
+
+    it("asks the user which method to use when a terminal is available", async () => {
+      const conn = connection();
+      const ask = vi.fn().mockResolvedValue("1");
+      const used = await login({
+        connection: conn,
+        methods: [agentMethod, terminalMethod],
+        launch,
+        interactive: true,
+        ask,
+      });
+      expect(used).toBe(agentMethod);
+      expect(ask).toHaveBeenCalled();
+    });
+
+    it("fails when only a terminal login is offered and no terminal is available", async () => {
+      await expect(
+        login({ connection: connection(), methods: [terminalMethod], launch }),
+      ).rejects.toThrow(/No usable authentication method/);
+    });
+
+    it("fails when the user does not choose a method", async () => {
+      await expect(
+        login({
+          connection: connection(),
+          methods: [agentMethod, terminalMethod],
+          launch,
+          interactive: true,
+          ask: vi.fn().mockResolvedValue("nonsense"),
+        }),
+      ).rejects.toThrow(/No usable authentication method/);
+    });
+  });
+
+  describe("supportsLogout", () => {
+    it("is true only when the agent advertises the capability", () => {
+      expect(supportsLogout({ auth: { logout: {} } } as any)).toBe(true);
+      expect(supportsLogout({ auth: { logout: null } } as any)).toBe(false);
+      expect(supportsLogout({ auth: {} } as any)).toBe(false);
+      expect(supportsLogout({} as any)).toBe(false);
+      expect(supportsLogout(undefined)).toBe(false);
+    });
+  });
+
+  describe("logout", () => {
+    it("skips agents that do not implement logout", async () => {
+      const conn = { authenticate: vi.fn(), logout: vi.fn() };
+      expect(await logout(conn, {} as any)).toBe(false);
+      expect(conn.logout).not.toHaveBeenCalled();
+    });
+
+    it("ends the authenticated state when supported", async () => {
+      const conn = { authenticate: vi.fn(), logout: vi.fn().mockResolvedValue({}) };
+      expect(await logout(conn, { auth: { logout: {} } } as any)).toBe(true);
+      expect(conn.logout).toHaveBeenCalledWith({});
+    });
+  });
+});

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Writable, Readable } from "node:stream";
+import { EventEmitter } from "node:events";
+import * as acp from "@agentclientprotocol/sdk";
 import {
   createAcpSessionSwitcher,
   checkForNextTask,
@@ -7,18 +9,33 @@ import {
   TaskQueue,
   getOrCreateSession,
   activeSessions,
+  authConfig,
+  createSessionWithAuth,
+  isInteractiveTerminal,
+  openAgentConnection,
+  parseGatewayArgs,
+  printUsage,
   pickHumanApprovalMode,
   enforceHumanApprovalMode,
+  runAuthCommand,
 } from "../index.js";
+import { AUTH_REQUIRED_CODE } from "../auth.js";
 import type { McpServerConfig } from "../config.js";
 
-vi.mock("node:child_process", () => {
+// Real emitters so the agent-process lifecycle handlers can be exercised.
+const { spawnedAgents } = vi.hoisted(() => ({ spawnedAgents: [] as any[] }));
+
+vi.mock("node:child_process", async () => {
+  const { EventEmitter } = await import("node:events");
+  const { Writable, Readable } = await import("node:stream");
   return {
-    spawn: vi.fn().mockReturnValue({
-      stdin: new Writable({ write(chunk, encoding, callback) { callback(); } }),
-      stdout: new Readable({ read() { this.push(null); } }),
-      kill: vi.fn(),
-      on: vi.fn(),
+    spawn: vi.fn(() => {
+      const child: any = new EventEmitter();
+      child.stdin = new Writable({ write(chunk, encoding, callback) { callback(); } });
+      child.stdout = new Readable({ read() { this.push(null); } });
+      child.kill = vi.fn();
+      spawnedAgents.push(child);
+      return child;
     }),
   };
 });
@@ -430,6 +447,282 @@ describe("index", () => {
           }),
         }),
       );
+    });
+
+    it("should declare whether it can host a terminal login", async () => {
+      const mockBridge: any = {};
+
+      const session = await getOrCreateSession("T-Auth-Cap", ["node", "agent.js"], [], { env: {} } as any, mockBridge);
+
+      expect(session.connection.initialize).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clientCapabilities: expect.objectContaining({
+            auth: { terminal: isInteractiveTerminal() },
+          }),
+        }),
+      );
+    });
+
+    it("should log in and retry when the agent refuses the session", async () => {
+      const authenticate = vi.fn().mockResolvedValue({});
+      const newSession = vi
+        .fn()
+        .mockRejectedValueOnce(
+          Object.assign(new Error("Authentication required"), { code: AUTH_REQUIRED_CODE }),
+        )
+        .mockResolvedValue({ sessionId: "authed-sess" });
+      vi.mocked(acp.ClientSideConnection).mockImplementationOnce(function () {
+        return {
+          initialize: vi.fn().mockResolvedValue({
+            protocolVersion: "0.1.0",
+            authMethods: [{ id: "agent-login", name: "Agent login" }],
+          }),
+          newSession,
+          authenticate,
+          prompt: vi.fn(),
+        } as any;
+      } as any);
+
+      const session = await getOrCreateSession("T-Login", ["node", "agent.js"], [], { env: {} } as any, {} as any);
+
+      expect(authenticate).toHaveBeenCalledWith({ methodId: "agent-login" });
+      expect(newSession).toHaveBeenCalledTimes(2);
+      expect(session.sessionId).toBe("authed-sess");
+    });
+
+    it("should drop the cached session when the agent process dies", async () => {
+      const mockBridge: any = {};
+      await getOrCreateSession("T-Exit", ["node", "agent.js"], [], { env: {} } as any, mockBridge);
+      expect(activeSessions.has("T-Exit")).toBe(true);
+
+      spawnedAgents[spawnedAgents.length - 1].emit("exit", 1, null);
+      expect(activeSessions.has("T-Exit")).toBe(false);
+    });
+  });
+
+  describe("openAgentConnection", () => {
+    beforeEach(() => {
+      spawnedAgents.length = 0;
+    });
+
+    it("should report the agent's login methods and survive process failures", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      vi.mocked(acp.ClientSideConnection).mockImplementationOnce(function () {
+        return {
+          initialize: vi.fn().mockResolvedValue({
+            protocolVersion: "0.1.0",
+            authMethods: [{ id: "agent-login", name: "Agent login" }],
+          }),
+        } as any;
+      } as any);
+
+      const onExit = vi.fn();
+      const agent = await openAgentConnection({
+        acpCmdArgs: ["node", "agent.js"],
+        mcpBridge: {} as any,
+        label: "login",
+        onExit,
+      });
+
+      expect(agent.initResult.authMethods).toHaveLength(1);
+      expect(errorSpy.mock.calls.flat().join("\n")).toContain("Agent login (agent-login)");
+
+      agent.process.emit("error", new Error("spawn failed"));
+      agent.process.stdin.emit("error", new Error("EPIPE"));
+      expect(onExit).toHaveBeenCalledTimes(1);
+
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe("createSessionWithAuth", () => {
+    const auth = {
+      methods: [{ id: "agent-login", name: "Agent login" }] as any,
+      launch: { command: "node", args: ["agent.js"] },
+    };
+
+    it("should start the session directly when no login is needed", async () => {
+      const connection: any = {
+        newSession: vi.fn().mockResolvedValue({ sessionId: "s1" }),
+        authenticate: vi.fn(),
+      };
+
+      const result = await createSessionWithAuth(connection, {} as any, auth);
+
+      expect(result.sessionId).toBe("s1");
+      expect(connection.authenticate).not.toHaveBeenCalled();
+    });
+
+    it("should surface failures that are not about authentication", async () => {
+      const connection: any = {
+        newSession: vi.fn().mockRejectedValue(new Error("cwd does not exist")),
+        authenticate: vi.fn(),
+      };
+
+      await expect(createSessionWithAuth(connection, {} as any, auth)).rejects.toThrow(
+        "cwd does not exist",
+      );
+      expect(connection.authenticate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("parseGatewayArgs", () => {
+    it("should default to bridging tasks with a concurrency of 2", () => {
+      expect(parseGatewayArgs([])).toEqual({ maxConcurrency: 2, command: "run" });
+    });
+
+    it("should accept both spellings of the concurrency flag", () => {
+      expect(parseGatewayArgs(["--max-concurrency", "4"]).maxConcurrency).toBe(4);
+      expect(parseGatewayArgs(["--maxConcurrency", "8"]).maxConcurrency).toBe(8);
+    });
+
+    it("should keep the default when the concurrency value is missing or not a number", () => {
+      expect(parseGatewayArgs(["--max-concurrency"]).maxConcurrency).toBe(2);
+      expect(parseGatewayArgs(["--max-concurrency", "many"]).maxConcurrency).toBe(2);
+      expect(parseGatewayArgs(["--max-concurrency", "--logout"])).toEqual({
+        maxConcurrency: 2,
+        command: "logout",
+      });
+    });
+
+    it("should read the preferred auth method", () => {
+      expect(parseGatewayArgs(["--auth-method", "oauth"])).toEqual({
+        maxConcurrency: 2,
+        command: "run",
+        authMethodId: "oauth",
+      });
+      expect(parseGatewayArgs(["--auth-method"]).authMethodId).toBeUndefined();
+    });
+
+    it("should recognise the auth commands", () => {
+      expect(parseGatewayArgs(["--login"])).toEqual({ maxConcurrency: 2, command: "login" });
+      expect(parseGatewayArgs(["--login", "oauth"])).toEqual({
+        maxConcurrency: 2,
+        command: "login",
+        authMethodId: "oauth",
+      });
+      expect(parseGatewayArgs(["--logout"]).command).toBe("logout");
+      expect(parseGatewayArgs(["--list-auth-methods"]).command).toBe("list-auth-methods");
+    });
+
+    it("should ignore flags it does not know", () => {
+      expect(parseGatewayArgs(["--verbose", "--login"]).command).toBe("login");
+    });
+  });
+
+  describe("runAuthCommand", () => {
+    const agentrqConfig: any = { env: {} };
+    let logSpy: any;
+    let errorSpy: any;
+
+    function mockConnection(overrides: Record<string, any>, initResult: Record<string, any> = {}) {
+      const connection: Record<string, any> = {
+        initialize: vi.fn().mockResolvedValue({ protocolVersion: "0.1.0", ...initResult }),
+        ...overrides,
+      };
+      vi.mocked(acp.ClientSideConnection).mockImplementationOnce(function () {
+        return connection as any;
+      } as any);
+      return connection;
+    }
+
+    beforeEach(() => {
+      spawnedAgents.length = 0;
+      logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    it("should list the agent's login methods and shut the agent down again", async () => {
+      mockConnection({}, {
+        authMethods: [{ id: "agent-login", name: "Agent login" }],
+        agentCapabilities: { auth: { logout: {} } },
+      });
+
+      await runAuthCommand("list-auth-methods", ["gemini", "--acp"], agentrqConfig, {} as any);
+
+      const printed = logSpy.mock.calls.flat().join("\n");
+      expect(printed).toContain("Agent login (agent-login)");
+      expect(printed).toContain("--logout");
+      expect(spawnedAgents[0].kill).toHaveBeenCalled();
+    });
+
+    it("should report agents that advertise no login", async () => {
+      mockConnection({});
+
+      await runAuthCommand("list-auth-methods", ["gemini", "--acp"], agentrqConfig, {} as any);
+
+      expect(logSpy.mock.calls.flat().join("\n")).toContain("no authentication methods");
+    });
+
+    it("should log out", async () => {
+      const connection = mockConnection({ logout: vi.fn().mockResolvedValue({}) }, {
+        agentCapabilities: { auth: { logout: {} } },
+      });
+
+      await runAuthCommand("logout", ["gemini", "--acp"], agentrqConfig, {} as any);
+
+      expect(connection.logout).toHaveBeenCalledWith({});
+    });
+
+    it("should log in with the method the user named", async () => {
+      const connection = mockConnection({ authenticate: vi.fn().mockResolvedValue({}) }, {
+        authMethods: [
+          { id: "agent-login", name: "Agent login" },
+          { id: "oauth", name: "OAuth" },
+        ],
+      });
+
+      await runAuthCommand("login", ["gemini", "--acp"], agentrqConfig, {} as any, "oauth");
+
+      expect(connection.authenticate).toHaveBeenCalledWith({ methodId: "oauth" });
+    });
+
+    it("should still shut the agent down when the login fails", async () => {
+      mockConnection({ authenticate: vi.fn() }, {
+        authMethods: [{ id: "agent-login", name: "Agent login" }],
+      });
+
+      await expect(
+        runAuthCommand("login", ["gemini", "--acp"], agentrqConfig, {} as any, "missing"),
+      ).rejects.toThrow(/Unknown authentication method/);
+      expect(spawnedAgents[0].kill).toHaveBeenCalled();
+    });
+  });
+
+  describe("printUsage", () => {
+    it("should document the auth commands alongside the bridge usage", () => {
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      printUsage();
+      const printed = logSpy.mock.calls.flat().join("\n");
+      logSpy.mockRestore();
+
+      expect(printed).toContain("--list-auth-methods");
+      expect(printed).toContain("--login [method-id]");
+      expect(printed).toContain("--logout");
+      expect(printed).toContain("--auth-method <id>");
+    });
+  });
+
+  describe("authConfig", () => {
+    it("should start out with no preferred login method", () => {
+      expect(authConfig).toEqual({});
+    });
+  });
+
+  describe("isInteractiveTerminal", () => {
+    it("should be true only when both stdin and stderr are a TTY", () => {
+      const original = { stdin: process.stdin.isTTY, stderr: process.stderr.isTTY };
+      try {
+        process.stdin.isTTY = true;
+        process.stderr.isTTY = true;
+        expect(isInteractiveTerminal()).toBe(true);
+
+        process.stderr.isTTY = false;
+        expect(isInteractiveTerminal()).toBe(false);
+      } finally {
+        process.stdin.isTTY = original.stdin;
+        process.stderr.isTTY = original.stderr;
+      }
     });
   });
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,279 @@
+/**
+ * auth.ts
+ *
+ * ACP authentication support: reading the login methods an agent advertises
+ * during `initialize`, recognising the protocol's `auth_required` failure, and
+ * running either kind of login on the user's behalf.
+ *
+ * See https://agentclientprotocol.com/protocol/v1/authentication
+ */
+
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline/promises";
+import type * as acp from "@agentclientprotocol/sdk";
+
+/** JSON-RPC code ACP reserves for "the user must authenticate first". */
+export const AUTH_REQUIRED_CODE = -32000;
+
+/** The slice of the ACP connection the login and logout flows drive. */
+export interface AuthConnection {
+  authenticate(params: { methodId: string }): Promise<unknown>;
+  logout(params: Record<string, never>): Promise<unknown>;
+}
+
+/** How to re-run the configured agent binary for a `terminal` login. */
+export interface AgentLaunch {
+  command: string;
+  args: string[];
+  env?: Record<string, string | undefined>;
+}
+
+export type AuthMethodType = "agent" | "terminal";
+
+/**
+ * `type` discriminates the two kinds of auth method on the wire, and the
+ * protocol treats a missing `type` as `agent`.
+ */
+export function authMethodType(method: acp.AuthMethod): AuthMethodType {
+  return (method as { type?: string }).type === "terminal" ? "terminal" : "agent";
+}
+
+/** Renders the agent's login options as a numbered list for the terminal. */
+export function describeAuthMethods(
+  methods: readonly acp.AuthMethod[] | null | undefined,
+): string {
+  if (!methods?.length) {
+    return "The agent advertises no authentication methods — no login is needed.";
+  }
+  return methods
+    .map((m, i) => {
+      const kind = authMethodType(m) === "terminal" ? " [terminal login]" : "";
+      const description = m.description ? ` — ${m.description}` : "";
+      return `  ${i + 1}. ${m.name} (${m.id})${kind}${description}`;
+    })
+    .join("\n");
+}
+
+/** Pulls `code`/`message` out of a JSON-RPC failure in either shape it arrives in. */
+function errorParts(err: unknown): { code?: number; message: string } {
+  if (!err || typeof err !== "object") return { message: "" };
+  const candidate = err as { code?: unknown; message?: unknown; error?: unknown };
+  const source =
+    candidate.error && typeof candidate.error === "object"
+      ? (candidate.error as { code?: unknown; message?: unknown })
+      : candidate;
+  return {
+    code: typeof source.code === "number" ? source.code : undefined,
+    message: typeof source.message === "string" ? source.message : "",
+  };
+}
+
+/**
+ * Tells an "authenticate first" refusal apart from any other failure.
+ *
+ * ACP carries `auth_required` on the reserved code -32000, which agents also
+ * use for unrelated errors (a denied permission, for one), so the message has
+ * to agree before we send the user through a login.
+ */
+export function isAuthRequiredError(err: unknown): boolean {
+  const { code, message } = errorParts(err);
+  return code === AUTH_REQUIRED_CODE && /auth/i.test(message);
+}
+
+export interface PickAuthMethodOptions {
+  /** Method id the user named explicitly (`--auth-method`). */
+  preferredId?: string;
+  /** Whether this process can host an interactive `terminal` login. */
+  allowTerminal?: boolean;
+}
+
+/**
+ * Chooses the login method to run without asking anyone.
+ *
+ * An explicitly named id always wins. Otherwise `agent` methods come first:
+ * the agent drives those itself, so they work in an unattended gateway, while
+ * a `terminal` method needs a human at a TTY.
+ */
+export function pickAuthMethod(
+  methods: readonly acp.AuthMethod[] | null | undefined,
+  { preferredId, allowTerminal = false }: PickAuthMethodOptions = {},
+): acp.AuthMethod | undefined {
+  if (!methods?.length) return undefined;
+  if (preferredId) return methods.find((m) => m.id === preferredId);
+  return (
+    methods.find((m) => authMethodType(m) === "agent") ??
+    (allowTerminal ? methods.find((m) => authMethodType(m) === "terminal") : undefined)
+  );
+}
+
+/** Reads one line from the user; replaceable in tests. */
+export type Asker = (question: string) => Promise<string>;
+
+/** Asks on stderr so the gateway's stdout stays free for its own output. */
+async function askOnTerminal(question: string): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    return await rl.question(question);
+  } finally {
+    rl.close();
+  }
+}
+
+/**
+ * Asks the user which login to use, the way an editor would on first run.
+ *
+ * A single method needs no question. An empty answer takes the first method,
+ * and an unrecognised one re-asks rather than logging in with something the
+ * user did not choose.
+ */
+export async function promptForAuthMethod(
+  methods: readonly acp.AuthMethod[],
+  ask: Asker = askOnTerminal,
+): Promise<acp.AuthMethod | undefined> {
+  if (!methods.length) return undefined;
+  if (methods.length === 1) return methods[0];
+
+  console.error(`\n[auth] The agent requires a login. Available methods:\n${describeAuthMethods(methods)}`);
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const answer = (await ask(`[auth] Choose a method [1-${methods.length}, default 1]: `)).trim();
+    if (!answer) return methods[0];
+
+    const byIndex = Number(answer);
+    if (Number.isInteger(byIndex) && byIndex >= 1 && byIndex <= methods.length) {
+      return methods[byIndex - 1];
+    }
+    const byId = methods.find((m) => m.id === answer);
+    if (byId) return byId;
+
+    console.error(`[auth] "${answer}" is not one of the listed methods.`);
+  }
+  return undefined;
+}
+
+/**
+ * Runs a `terminal` login by re-launching the configured agent interactively.
+ *
+ * The protocol has the client reproduce its own agent invocation with the
+ * method's extra args and env, hand the process the user's terminal, and read
+ * success off the exit status.
+ */
+export async function runTerminalAuth(
+  method: acp.AuthMethod,
+  launch: AgentLaunch,
+): Promise<void> {
+  const extra = (method as { args?: string[] }).args ?? [];
+  const extraEnv = (method as { env?: Record<string, string> }).env ?? {};
+  const args = [...launch.args, ...extra];
+
+  console.error(
+    `[auth] Running terminal login: ${launch.command} ${args.join(" ")}\n` +
+      `[auth] Complete the login in your terminal; the gateway resumes when it exits.`,
+  );
+
+  const child = spawn(launch.command, args, {
+    stdio: "inherit",
+    env: { ...process.env, ...launch.env, ...extraEnv } as NodeJS.ProcessEnv,
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    child.on("error", (err: Error) =>
+      reject(new Error(`Terminal login "${method.id}" failed to start: ${err.message}`)),
+    );
+    child.on("exit", (code: number | null, signal: string | null) => {
+      if (code === 0) return resolve();
+      reject(
+        new Error(
+          `Terminal login "${method.id}" failed (code=${code}, signal=${signal}).`,
+        ),
+      );
+    });
+  });
+}
+
+/** Runs whichever kind of login the chosen method calls for. */
+export async function runAuthMethod(
+  connection: AuthConnection,
+  method: acp.AuthMethod,
+  launch: AgentLaunch,
+): Promise<void> {
+  if (authMethodType(method) === "terminal") {
+    await runTerminalAuth(method, launch);
+  } else {
+    // A `terminal` method must never reach `authenticate` — the agent does not
+    // implement one for it.
+    await connection.authenticate({ methodId: method.id });
+  }
+  console.error(`[auth] Logged in with "${method.name}" (${method.id}).`);
+}
+
+export interface LoginOptions {
+  connection: AuthConnection;
+  methods: readonly acp.AuthMethod[] | null | undefined;
+  launch: AgentLaunch;
+  /** Method id the user named explicitly (`--auth-method`, `--login <id>`). */
+  preferredId?: string;
+  /** Whether a human is present to answer a prompt and finish a terminal login. */
+  interactive?: boolean;
+  ask?: Asker;
+}
+
+/**
+ * Logs in: picks a method — asking the user when one is there to ask — and
+ * runs it. Returns the method used, or undefined when the agent advertises no
+ * login at all.
+ */
+export async function login({
+  connection,
+  methods,
+  launch,
+  preferredId,
+  interactive = false,
+  ask,
+}: LoginOptions): Promise<acp.AuthMethod | undefined> {
+  if (!methods?.length) {
+    console.error("[auth] The agent advertises no authentication methods; nothing to log in to.");
+    return undefined;
+  }
+
+  let method = pickAuthMethod(methods, { preferredId, allowTerminal: interactive });
+  if (preferredId && !method) {
+    throw new Error(
+      `Unknown authentication method "${preferredId}". Available:\n${describeAuthMethods(methods)}`,
+    );
+  }
+  if (!preferredId && interactive) {
+    method = await promptForAuthMethod(methods, ask);
+  }
+  if (!method) {
+    throw new Error(
+      `No usable authentication method. Available:\n${describeAuthMethods(methods)}\n` +
+        `Terminal logins need an interactive terminal; re-run acp-gateway from one, ` +
+        `or pass --auth-method <id>.`,
+    );
+  }
+
+  await runAuthMethod(connection, method, launch);
+  return method;
+}
+
+/** Whether the agent said it implements `logout` during `initialize`. */
+export function supportsLogout(
+  agentCapabilities: acp.InitializeResponse["agentCapabilities"] | null | undefined,
+): boolean {
+  const auth = (agentCapabilities as { auth?: { logout?: unknown } } | null | undefined)?.auth;
+  return auth?.logout !== undefined && auth?.logout !== null;
+}
+
+/** Ends the agent's authenticated state, if it implements logout. */
+export async function logout(
+  connection: AuthConnection,
+  agentCapabilities: acp.InitializeResponse["agentCapabilities"] | null | undefined,
+): Promise<boolean> {
+  if (!supportsLogout(agentCapabilities)) {
+    console.error("[auth] The agent does not support logout.");
+    return false;
+  }
+  await connection.logout({});
+  console.error("[auth] Logged out.");
+  return true;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,15 @@ export function mapMcpServers(configs: McpServerConfig[]): acp.McpServer[] {
 }
 import { AgentRQACPClient } from "./acpClient.js";
 import {
+  describeAuthMethods,
+  isAuthRequiredError,
+  login,
+  logout,
+  supportsLogout,
+  type AuthConnection,
+  type LoginOptions,
+} from "./auth.js";
+import {
   extractTaskIdFromMeta,
   extractTaskIdFromText,
 } from "./taskIdentity.js";
@@ -49,48 +58,81 @@ export interface AgentSession {
   connection: acp.ClientSideConnection;
   acpClient: AgentRQACPClient;
   sessionId: string;
+  initResult: acp.InitializeResponse;
 }
 
 export const activeSessions = new Map<string, AgentSession>();
 
-export async function getOrCreateSession(
-  taskId: string | undefined,
-  acpCmdArgs: string[],
-  configs: McpServerConfig[],
-  agentrqConfig: McpServerConfig,
-  mcpBridge: MCPBridge,
-): Promise<AgentSession> {
-  const key = taskId || "default";
-  const existing = activeSessions.get(key);
-  if (existing) {
-    return existing;
-  }
+/** Login preferences taken from the CLI, consulted whenever an agent demands auth. */
+export const authConfig: { methodId?: string } = {};
 
+/**
+ * Whether a human is sitting in front of this process.
+ *
+ * Terminal logins hand the agent our own stdio, and the "which login method?"
+ * prompt needs someone to answer it — neither works when the gateway runs
+ * unattended under a supervisor.
+ */
+export function isInteractiveTerminal(): boolean {
+  return Boolean(process.stdin.isTTY && process.stderr.isTTY);
+}
+
+export interface AgentConnection {
+  process: any;
+  connection: acp.ClientSideConnection;
+  acpClient: AgentRQACPClient;
+  initResult: acp.InitializeResponse;
+}
+
+export interface OpenAgentConnectionOptions {
+  acpCmdArgs: string[];
+  mcpBridge: MCPBridge;
+  env?: Record<string, string>;
+  /** Used in log lines to say which agent process is being talked about. */
+  label: string;
+  taskId?: string;
+  /** Runs when the agent process dies or fails to start. */
+  onExit?: () => void;
+}
+
+/**
+ * Spawns an ACP agent, wires the JSON-RPC streams to it and completes the
+ * `initialize` handshake, returning the connection plus what the agent said
+ * about itself — including the login methods it advertises.
+ */
+export async function openAgentConnection({
+  acpCmdArgs,
+  mcpBridge,
+  env,
+  label,
+  taskId,
+  onExit,
+}: OpenAgentConnectionOptions): Promise<AgentConnection> {
   const [cmd, ...cmdArgs] = acpCmdArgs;
-  console.error(`[acp] Spawning agent for task ${key}: ${cmd} ${cmdArgs.join(" ")}`);
+  console.error(`[acp] Spawning agent for ${label}: ${cmd} ${cmdArgs.join(" ")}`);
 
   const agentProcess = spawn(cmd, cmdArgs, {
     stdio: ["pipe", "pipe", "inherit"],
-    env: { ...process.env, ...agentrqConfig.env },
+    env: { ...process.env, ...env },
   });
 
   // Guard against unhandled child-process failures. Without these listeners a
   // crashed agent (e.g. on network loss) leaves a broken stdin pipe; the next
   // write raises EPIPE as an uncaught error and takes the gateway down with it.
   agentProcess.on("error", (err: Error) => {
-    console.error(`[acp] Agent process error for task ${key}:`, err.message);
-    activeSessions.delete(key);
+    console.error(`[acp] Agent process error for ${label}:`, err.message);
+    onExit?.();
   });
   agentProcess.on("exit", (code: number | null, signal: string | null) => {
     console.error(
-      `[acp] Agent process for task ${key} exited (code=${code}, signal=${signal})`,
+      `[acp] Agent process for ${label} exited (code=${code}, signal=${signal})`,
     );
-    activeSessions.delete(key);
+    onExit?.();
   });
   // stdin can emit EPIPE when the child dies mid-write; swallow it so it
   // doesn't surface as an uncaught exception.
   agentProcess.stdin?.on("error", (err: Error) => {
-    console.error(`[acp] Agent stdin error for task ${key}:`, err.message);
+    console.error(`[acp] Agent stdin error for ${label}:`, err.message);
   });
 
   const input = Writable.toWeb(agentProcess.stdin!);
@@ -116,19 +158,82 @@ export async function getOrCreateSession(
         form: {},
         url: {},
       },
+      // Only claim terminal logins when we can actually hand the agent a
+      // terminal; otherwise the agent may offer a method we cannot run.
+      auth: {
+        terminal: isInteractiveTerminal(),
+      },
     },
   });
 
   console.error(
-    `[acp] Connected to agent for task ${key} (protocol v${initResult.protocolVersion})`,
+    `[acp] Connected to agent for ${label} (protocol v${initResult.protocolVersion})`,
   );
+  if (initResult.authMethods?.length) {
+    console.error(
+      `[auth] Agent offers these login methods:\n${describeAuthMethods(initResult.authMethods)}`,
+    );
+  }
+
+  return { process: agentProcess, connection, acpClient, initResult };
+}
+
+/**
+ * Starts a session, logging in first if the agent refuses without one.
+ *
+ * Agents only report `auth_required` when the session is requested, so this is
+ * where a first-run login belongs: authenticate once, then retry.
+ */
+export async function createSessionWithAuth(
+  connection: acp.ClientSideConnection,
+  params: AcpNewSessionParams,
+  auth: Omit<LoginOptions, "connection">,
+): Promise<acp.NewSessionResponse> {
+  try {
+    return await connection.newSession(params);
+  } catch (err) {
+    if (!isAuthRequiredError(err)) throw err;
+    console.error("[auth] Agent requires authentication before a session can start.");
+    await login({ ...auth, connection: connection as unknown as AuthConnection });
+    return await connection.newSession(params);
+  }
+}
+
+export async function getOrCreateSession(
+  taskId: string | undefined,
+  acpCmdArgs: string[],
+  configs: McpServerConfig[],
+  agentrqConfig: McpServerConfig,
+  mcpBridge: MCPBridge,
+): Promise<AgentSession> {
+  const key = taskId || "default";
+  const existing = activeSessions.get(key);
+  if (existing) {
+    return existing;
+  }
+
+  const [cmd, ...cmdArgs] = acpCmdArgs;
+  const { process: agentProcess, connection, acpClient, initResult } =
+    await openAgentConnection({
+      acpCmdArgs,
+      mcpBridge,
+      env: agentrqConfig.env,
+      label: `task ${key}`,
+      taskId,
+      onExit: () => activeSessions.delete(key),
+    });
 
   const newSessionParams: AcpNewSessionParams = {
     cwd: process.cwd(),
     mcpServers: mapMcpServers(configs),
   };
 
-  const sessionResult = await connection.newSession(newSessionParams);
+  const sessionResult = await createSessionWithAuth(connection, newSessionParams, {
+    methods: initResult.authMethods,
+    launch: { command: cmd, args: cmdArgs, env: agentrqConfig.env },
+    preferredId: authConfig.methodId,
+    interactive: isInteractiveTerminal(),
+  });
   console.error(`[acp] Created session ${sessionResult.sessionId} for task ${key}`);
 
   await enforceHumanApprovalMode(connection, sessionResult);
@@ -138,6 +243,7 @@ export async function getOrCreateSession(
     connection,
     acpClient,
     sessionId: sessionResult.sessionId,
+    initResult,
   };
   activeSessions.set(key, sessionInfo);
   return sessionInfo;
@@ -313,6 +419,125 @@ export class TaskQueue {
   }
 }
 
+/** What the gateway was asked to do, beyond bridging tasks. */
+export type GatewayCommand = "run" | "login" | "logout" | "list-auth-methods";
+
+export interface GatewayOptions {
+  maxConcurrency: number;
+  authMethodId?: string;
+  command: GatewayCommand;
+}
+
+/**
+ * Parses the gateway's own flags — everything before the `--` that introduces
+ * the agent command.
+ */
+export function parseGatewayArgs(args: string[]): GatewayOptions {
+  const options: GatewayOptions = { maxConcurrency: 2, command: "run" };
+
+  for (let i = 0; i < args.length; i++) {
+    // A following token is this flag's value only when it isn't a flag itself,
+    // so `--login` can stand alone or take a method id.
+    const next = args[i + 1];
+    const value = next !== undefined && !next.startsWith("-") ? next : undefined;
+
+    switch (args[i]) {
+      case "--max-concurrency":
+      case "--maxConcurrency": {
+        const parsed = parseInt(value ?? "", 10);
+        if (!isNaN(parsed)) {
+          options.maxConcurrency = parsed;
+          i++;
+        }
+        break;
+      }
+      case "--auth-method":
+        if (value) {
+          options.authMethodId = value;
+          i++;
+        }
+        break;
+      case "--login":
+        options.command = "login";
+        if (value) {
+          options.authMethodId = value;
+          i++;
+        }
+        break;
+      case "--logout":
+        options.command = "logout";
+        break;
+      case "--list-auth-methods":
+        options.command = "list-auth-methods";
+        break;
+    }
+  }
+
+  return options;
+}
+
+/**
+ * Runs a one-shot auth command against the agent and shuts it down again.
+ *
+ * These commands exist so a login can be done deliberately — before any task
+ * arrives — rather than only when a session is refused.
+ */
+export async function runAuthCommand(
+  command: Exclude<GatewayCommand, "run">,
+  acpCmdArgs: string[],
+  agentrqConfig: McpServerConfig,
+  mcpBridge: MCPBridge,
+  authMethodId?: string,
+): Promise<void> {
+  const [cmd, ...cmdArgs] = acpCmdArgs;
+  const agent = await openAgentConnection({
+    acpCmdArgs,
+    mcpBridge,
+    env: agentrqConfig.env,
+    label: command,
+  });
+
+  try {
+    const connection = agent.connection as unknown as AuthConnection;
+    const { authMethods, agentCapabilities } = agent.initResult;
+
+    if (command === "list-auth-methods") {
+      console.log(
+        `Authentication methods for "${acpCmdArgs.join(" ")}":\n${describeAuthMethods(authMethods)}`,
+      );
+      if (supportsLogout(agentCapabilities)) {
+        console.log("\nThe agent also supports --logout.");
+      }
+      return;
+    }
+
+    if (command === "logout") {
+      await logout(connection, agentCapabilities);
+      return;
+    }
+
+    await login({
+      connection,
+      methods: authMethods,
+      launch: { command: cmd, args: cmdArgs, env: agentrqConfig.env },
+      preferredId: authMethodId,
+      interactive: isInteractiveTerminal(),
+    });
+  } finally {
+    agent.process.kill();
+  }
+}
+
+export function printUsage(): void {
+  console.log(
+    "Usage: acp-gateway [--max-concurrency <number>] [--auth-method <id>] -- <acp-server-command> [args...]",
+  );
+  console.log("       acp-gateway --list-auth-methods -- <acp-server-command> [args...]");
+  console.log("       acp-gateway --login [method-id] -- <acp-server-command> [args...]");
+  console.log("       acp-gateway --logout -- <acp-server-command> [args...]");
+  console.log("Example: acp-gateway --max-concurrency 4 -- gemini --acp");
+}
+
 async function main() {
   console.log(`Starting [acp-gateway] ${pkg.name} v${pkg.version}`);
 
@@ -324,8 +549,7 @@ async function main() {
     cmdStartIndex !== -1 ? args.slice(cmdStartIndex + 1) : args;
 
   if (acpCmdArgs.length === 0) {
-    console.log("Usage: acp-gateway [--max-concurrency <number>] -- <acp-server-command> [args...]");
-    console.log("Example: acp-gateway --max-concurrency 4 -- gemini --acp");
+    printUsage();
     process.exit(1);
   }
 
@@ -333,23 +557,28 @@ async function main() {
   const configs = loadMcpConfig();
   const agentrqConfig = pickAgentrqServer(configs);
 
-  // Parse max concurrency from CLI args, falling back to default of 2
-  let maxConcurrency = 2;
   const gatewayArgs = cmdStartIndex !== -1 ? args.slice(0, cmdStartIndex) : [];
-  const maxConcurrencyIdx = gatewayArgs.findIndex(
-    (arg) => arg === "--max-concurrency" || arg === "--maxConcurrency",
-  );
-  if (maxConcurrencyIdx !== -1 && maxConcurrencyIdx + 1 < gatewayArgs.length) {
-    const val = parseInt(gatewayArgs[maxConcurrencyIdx + 1], 10);
-    if (!isNaN(val)) {
-      maxConcurrency = val;
-    }
-  }
+  const { maxConcurrency, command, authMethodId } = parseGatewayArgs(gatewayArgs);
+  authConfig.methodId = authMethodId;
 
   const taskQueue = new TaskQueue(maxConcurrency);
 
   // 2. Initialize MCP Bridge
   const mcpBridge = new MCPBridge(agentrqConfig);
+
+  // Auth commands talk to the agent and exit; they never start bridging tasks.
+  // They run before the bridge connects, so a first-time login still works when
+  // the workspace is unreachable — `callTool` connects on demand if the login
+  // actually needs to reach agentrq.
+  if (command !== "run") {
+    try {
+      await runAuthCommand(command, acpCmdArgs, agentrqConfig, mcpBridge, authMethodId);
+    } finally {
+      await mcpBridge.close();
+    }
+    process.exit(0);
+  }
+
   await mcpBridge.connect();
 
   try {


### PR DESCRIPTION
## What changed

The gateway can now log in to agents that require authentication. It reads the login methods an agent advertises during the handshake, and when an agent refuses to start a session until you have signed in, it logs in and carries on — asking which method to use when someone is at the terminal, and choosing one by itself when running unattended. Logging in (or out) can also be done deliberately, ahead of any task, through four new command-line options.

## Why changed

Agents that need a sign-in were simply unusable: the gateway never offered a login, so every task against a signed-out agent failed at session creation with an opaque error. This is what an editor like Zed does on first run, and the gateway now does the same.

## Test coverage report

- **New lines: 100%** — the new authentication module is at 100% statements, branches and functions; every new line outside the `main()` entry point is covered. The 8 uncovered new lines are command-line wiring inside `main()`, which the suite has never invoked (it was already 0% covered there before this change).
- **Total coverage impact:** statements 80.93% → 86.11%, branches 81.41% → 87.91%, lines 81.19% → 86.24%, functions 71.76% → 81.98%.
- Test count: 112 → 170, all passing. `npm run typecheck` and `npm run build` clean.

## Other reports

Verified end to end against a stub agent that refuses to open a session until authenticated: the refusal is detected, the login is performed, and the session is created on the retry. Listing methods, logging in with a named method, and logging out were each exercised the same way.

TaskID: 0i4Oc1pd2NF
