### PR TITLE
feat: run agents by id from the ACP registry, and explain the options

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ acp-gateway -- your-acp-agent --flag1 --flag2
 You can specify gateway options before the `--` separator:
 
 - `--max-concurrency` / `--maxConcurrency` `<number>`: Sets the maximum number of concurrent tasks allowed to prompt the ACP agent at once. Defaults to `2`.
+- `--agent <registry-id>`: Runs an agent from the ACP registry instead of a command you supply yourself.
+- `--list-agents`: Prints every agent in the registry and how each one can run on this machine, then exits.
+- `--allow-unverified-agent`: Installs a registry binary that publishes no checksum. Off by default.
+- `--registry-url <url>`: Reads a different registry index (for pinning, or for testing).
 - `--auth-method <id>`: The authentication method to use when the agent asks for a login. Defaults to picking one automatically.
 - `--list-auth-methods`: Prints the login methods the agent advertises, then exits.
 - `--login [method-id]`: Logs in to the agent, then exits.
@@ -75,6 +79,48 @@ Example:
 ```bash
 acp-gateway --max-concurrency 4 -- gemini --acp
 ```
+
+### Running an Agent from the Registry
+
+The [ACP registry](https://github.com/agentclientprotocol/registry) lists agents that implement the
+protocol, and `acp-gateway` can run one by name — no installing or wiring up by hand:
+
+```bash
+acp-gateway --list-agents          # see what's published
+acp-gateway --agent gemini         # run one
+```
+
+Registry entries are distributed in three ways, and the gateway prefers them in this order:
+
+| Distribution | How it runs | Downloads anything? |
+|---|---|---|
+| `npx` | `npx -y <package> <args>` | No — npm fetches and verifies the package |
+| `uvx` | `uvx <package> <args>` | No — uv fetches and verifies the package |
+| `binary` | Archive is downloaded, checked, unpacked and cached | Yes |
+
+Package distributions come first because npm and PyPI verify what they serve. A binary is only used
+when it is the agent's only distribution.
+
+**Binaries are verified before they run.** The registry's `sha256` for the archive is optional, and
+roughly half of the published binary targets omit it. Where there is no checksum the gateway refuses
+to install rather than run something it cannot vouch for:
+
+```
+The ACP registry publishes no sha256 for "antigravity-acp" on this platform, so the download
+cannot be verified. Re-run with --allow-unverified-agent to install it anyway, or install the
+agent yourself and pass it after --.
+```
+
+Downloads are cached per agent, version and platform, so each build is fetched once:
+
+| Platform | Cache location |
+|---|---|
+| macOS / Linux | `$XDG_CACHE_HOME/acp-gateway/agents`, else `~/.cache/acp-gateway/agents` |
+| Windows | `%LOCALAPPDATA%\acp-gateway\agents` |
+
+All six platforms the registry publishes for are supported — macOS, Linux and Windows on both x86_64
+and arm64. Archives are unpacked with the system's own `tar` (and `unzip` for zips on Linux, whose
+`tar` cannot read them), so no archive libraries are added as dependencies.
 
 ### Authentication
 
@@ -175,6 +221,8 @@ Example `.mcp.json`:
 | `src/mcpClient.ts` | `EventEmitter`-based MCP client with auto-reconnection, notification handling, and tool call dispatch. |
 | `src/config.ts` | Parses `.mcp.json` from the current directory tree up to 3 levels deep. |
 | `src/auth.ts` | ACP authentication — lists the agent's login methods, detects `auth_required`, and runs agent or terminal logins. |
+| `src/registry.ts` | Reads the ACP registry index — agent lookup, host platform matching, and package launch commands. |
+| `src/agentInstall.ts` | Downloads, verifies, unpacks and caches a registry agent's binary distribution. |
 
 ## Development
 
@@ -197,10 +245,12 @@ npm test
 acp-gateway/
 ├── src/
 │   ├── acpClient.ts      # ACP Client implementation
+│   ├── agentInstall.ts    # Registry binary download / verify / cache
 │   ├── auth.ts            # ACP authentication (login / logout)
 │   ├── config.ts          # .mcp.json loader
 │   ├── index.ts           # Entry point & orchestrator
 │   ├── mcpClient.ts       # MCP Bridge with auto-reconnect
+│   ├── registry.ts        # ACP registry index client
 │   └── __tests__/         # Unit tests
 ├── package.json
 └── tsconfig.json
@@ -211,6 +261,7 @@ acp-gateway/
 - **Auto-reconnection**: The MCP transport auto-reconnects on disconnection with exponential backoff (1s → 30s max).
 - **Notification-driven tasks**: The MCP server pushes task content via `notifications/claude/channel`; `acp-gateway` reacts immediately.
 - **Permission flow**: ACP agent requests permission → `acp-gateway` forwards to MCP server → waits for verdict → resolves the ACP permission.
+- **Registry agents**: `--agent <id>` resolves through the registry index; package distributions are preferred over binaries, and a binary without a published `sha256` is refused unless explicitly allowed.
 - **Authentication**: Login methods come from the `initialize` handshake; an `auth_required` refusal triggers a login and one retry of `newSession`.
 - **File I/O**: `readTextFile` / `writeTextFile` are proxied directly to the filesystem; paths are resolved relative to `process.cwd()`.
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ You can specify gateway options before the `--` separator:
 - `--allow-unverified-agent`: Installs a registry binary that publishes no checksum. Off by default.
 - `--registry-url <url>`: Reads a different registry index (for pinning, or for testing).
 - `--auth-method <id>`: The authentication method to use when the agent asks for a login. Defaults to picking one automatically.
+- `--help` / `-h`: Explains every option, with examples. Also shown when `acp-gateway` is run with nothing to do.
 - `--list-auth-methods`: Prints the login methods the agent advertises, then exits.
 - `--login [method-id]`: Logs in to the agent, then exits.
 - `--logout`: Ends the agent's authenticated state, then exits (only for agents that support logout).

--- a/src/__tests__/agentInstall.test.ts
+++ b/src/__tests__/agentInstall.test.ts
@@ -1,0 +1,462 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import {
+  archiveKind,
+  assertChecksum,
+  assertVerifiable,
+  defaultCacheDir,
+  downloadArchive,
+  extractArchive,
+  installBinaryAgent,
+  installDir,
+  moveInto,
+  resolveAgentLaunch,
+  runExtractionTool,
+  resolveExecutable,
+  sha256,
+} from "../agentInstall.js";
+import type { BinaryTarget, Registry, RegistryAgent } from "../registry.js";
+
+const agent: RegistryAgent = {
+  id: "demo-acp",
+  name: "Demo Agent",
+  version: "1.2.3",
+  description: "A demo agent",
+  distribution: {},
+};
+
+/** Builds a real .tar.gz containing an executable, so extraction is exercised for real. */
+async function makeTarball(cmdName: string, contents: string): Promise<Uint8Array> {
+  const staging = await mkdtemp(path.join(tmpdir(), "acp-gateway-fixture-"));
+  try {
+    await writeFile(path.join(staging, cmdName), contents);
+    const archive = path.join(staging, "out.tar.gz");
+    execFileSync("tar", ["-czf", archive, "-C", staging, cmdName]);
+    return new Uint8Array(await readFile(archive));
+  } finally {
+    await rm(staging, { recursive: true, force: true });
+  }
+}
+
+function okResponse(data: Uint8Array): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    arrayBuffer: async () => data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength),
+  } as Response;
+}
+
+describe("agentInstall", () => {
+  let cacheDir: string;
+  let errorSpy: any;
+
+  beforeEach(async () => {
+    cacheDir = await mkdtemp(path.join(tmpdir(), "acp-gateway-cache-"));
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    errorSpy.mockRestore();
+    await rm(cacheDir, { recursive: true, force: true });
+  });
+
+  describe("defaultCacheDir", () => {
+    it("uses XDG_CACHE_HOME where it is set", () => {
+      expect(defaultCacheDir("linux", { XDG_CACHE_HOME: "/xdg" })).toBe(
+        path.join("/xdg", "acp-gateway", "agents"),
+      );
+    });
+
+    it("falls back to the per-user cache on macOS and Linux", () => {
+      expect(defaultCacheDir("darwin", {})).toMatch(/\.cache[\\/]acp-gateway[\\/]agents$/);
+    });
+
+    it("uses LOCALAPPDATA on Windows", () => {
+      expect(defaultCacheDir("win32", { LOCALAPPDATA: "C:\\Users\\me\\AppData\\Local" })).toBe(
+        path.join("C:\\Users\\me\\AppData\\Local", "acp-gateway", "agents"),
+      );
+      expect(defaultCacheDir("win32", {})).toMatch(/AppData[\\/]Local[\\/]acp-gateway/);
+    });
+  });
+
+  describe("archiveKind", () => {
+    it("recognises every format the registry allows", () => {
+      expect(archiveKind("https://x/y.zip")).toBe("zip");
+      expect(archiveKind("https://x/y.tar.gz")).toBe("tar.gz");
+      expect(archiveKind("https://x/y.tgz")).toBe("tar.gz");
+      expect(archiveKind("https://x/y.tar.bz2")).toBe("tar.bz2");
+      expect(archiveKind("https://x/y.tbz2")).toBe("tar.bz2");
+    });
+
+    it("ignores query strings and fragments", () => {
+      expect(archiveKind("https://x/y.ZIP?token=abc#frag")).toBe("zip");
+    });
+
+    it("treats anything else as a raw executable", () => {
+      expect(archiveKind("https://x/agent-darwin-arm64")).toBe("raw");
+    });
+  });
+
+  describe("installDir", () => {
+    it("keeps each version and platform apart", () => {
+      expect(installDir("/cache", "demo", "darwin-aarch64", "1.2.3")).toBe(
+        path.join("/cache", "demo@1.2.3", "darwin-aarch64"),
+      );
+    });
+  });
+
+  describe("resolveExecutable", () => {
+    it("resolves the registry's cmd inside the install directory", () => {
+      expect(resolveExecutable("/cache/demo", "./bin/agent")).toBe(
+        path.resolve("/cache/demo/bin/agent"),
+      );
+    });
+
+    it("refuses a cmd that climbs out of the install directory", () => {
+      expect(() => resolveExecutable("/cache/demo", "../../../usr/bin/curl")).toThrow(
+        /points outside its install directory/,
+      );
+    });
+  });
+
+  describe("assertVerifiable", () => {
+    const unverifiable: BinaryTarget = { archive: "https://x/y.zip", cmd: "./demo" };
+
+    it("refuses an archive the registry publishes no checksum for", () => {
+      expect(() => assertVerifiable(agent, unverifiable, false)).toThrow(
+        /publishes no sha256 for "demo-acp".*--allow-unverified-agent/s,
+      );
+    });
+
+    it("allows it once the user has explicitly opted in", () => {
+      expect(() => assertVerifiable(agent, unverifiable, true)).not.toThrow();
+    });
+
+    it("allows an archive that does publish a checksum", () => {
+      expect(() =>
+        assertVerifiable(agent, { ...unverifiable, sha256: "a".repeat(64) }, false),
+      ).not.toThrow();
+    });
+  });
+
+  describe("assertChecksum", () => {
+    const data = new Uint8Array([1, 2, 3]);
+
+    it("accepts a download that matches, whatever the case", () => {
+      const digest = sha256(data);
+      expect(() =>
+        assertChecksum(agent, { archive: "https://x/y", cmd: "./d", sha256: digest.toUpperCase() }, data),
+      ).not.toThrow();
+    });
+
+    it("refuses a download that does not match", () => {
+      expect(() =>
+        assertChecksum(agent, { archive: "https://x/y", cmd: "./d", sha256: "b".repeat(64) }, data),
+      ).toThrow(/Checksum mismatch for "demo-acp"/);
+    });
+
+    it("has nothing to check when the registry publishes no checksum", () => {
+      expect(() => assertChecksum(agent, { archive: "https://x/y", cmd: "./d" }, data)).not.toThrow();
+    });
+  });
+
+  describe("downloadArchive", () => {
+    it("returns the bytes", async () => {
+      const data = new Uint8Array([9, 8, 7]);
+      const fetchImpl = vi.fn().mockResolvedValue(okResponse(data));
+
+      expect(await downloadArchive("https://x/y.zip", fetchImpl as any)).toEqual(data);
+    });
+
+    it("reports a failed download", async () => {
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValue({ ok: false, status: 403, statusText: "Forbidden" });
+
+      await expect(downloadArchive("https://x/y.zip", fetchImpl as any)).rejects.toThrow(
+        /Failed to download https:\/\/x\/y.zip: 403 Forbidden/,
+      );
+    });
+  });
+
+  describe("extractArchive", () => {
+    it("writes a raw download straight out as the executable", async () => {
+      const dir = path.join(cacheDir, "raw");
+      await extractArchive(new Uint8Array([1, 2]), "raw", dir, "./demo-agent");
+
+      expect(await readFile(path.join(dir, "demo-agent"))).toEqual(Buffer.from([1, 2]));
+    });
+
+    it("unpacks a real tarball and removes the archive afterwards", async () => {
+      const tarball = await makeTarball("demo", "#!/bin/sh\necho hi\n");
+      const dir = path.join(cacheDir, "tar");
+
+      await extractArchive(tarball, "tar.gz", dir, "./demo");
+
+      expect(await readFile(path.join(dir, "demo"), "utf8")).toContain("echo hi");
+      expect(existsSync(path.join(dir, "archive.tar.gz"))).toBe(false);
+    });
+
+    it("uses unzip for zips on Linux, where tar cannot read them", async () => {
+      const dir = path.join(cacheDir, "zip");
+      // `unzip` is not guaranteed on every machine, so assert on the failure
+      // message rather than on a successful extraction.
+      await expect(
+        extractArchive(new Uint8Array([1]), "zip", dir, "./demo", "linux"),
+      ).rejects.toThrow(/unzip/);
+    });
+
+    it("reports an extraction tool that is not installed", async () => {
+      await expect(
+        runExtractionTool("acp-gateway-no-such-tool", [], cacheDir),
+      ).rejects.toThrow(/Could not run "acp-gateway-no-such-tool" to unpack the agent archive/);
+    });
+
+    it("reports a corrupt archive with the tool's own diagnostics", async () => {
+      const dir = path.join(cacheDir, "bad");
+      await expect(
+        extractArchive(new Uint8Array([1, 2, 3]), "tar.gz", dir, "./demo", "darwin"),
+      ).rejects.toThrow(/failed to unpack the agent archive/);
+    });
+  });
+
+  describe("moveInto", () => {
+    it("copies when the staged install cannot simply be renamed into place", async () => {
+      const from = await mkdtemp(path.join(tmpdir(), "acp-gateway-move-"));
+      await writeFile(path.join(from, "demo"), "binary");
+      // A destination whose parents do not exist: rename() fails, and the copy
+      // fallback — the same path taken when the temp dir is another mount —
+      // has to create the tree.
+      const to = path.join(cacheDir, "deep", "deeper", "install");
+
+      await moveInto(from, to);
+
+      expect(await readFile(path.join(to, "demo"), "utf8")).toBe("binary");
+      await rm(from, { recursive: true, force: true });
+    });
+  });
+
+  describe("installBinaryAgent", () => {
+    async function install(overrides: Record<string, any> = {}) {
+      const tarball = await makeTarball("demo", "#!/bin/sh\nexit 0\n");
+      const target: BinaryTarget = {
+        archive: "https://example.com/demo.tar.gz",
+        sha256: sha256(tarball),
+        cmd: "./demo",
+        args: ["--acp"],
+        ...overrides.target,
+      };
+      const fetchImpl = vi.fn().mockResolvedValue(okResponse(tarball));
+      const spec = await installBinaryAgent({
+        agent,
+        target,
+        platformTarget: "darwin-aarch64",
+        cacheDir,
+        fetchImpl: fetchImpl as any,
+        platform: "darwin",
+        ...overrides.options,
+      });
+      return { spec, fetchImpl, tarball };
+    }
+
+    it("downloads, verifies, unpacks and makes the agent executable", async () => {
+      const { spec } = await install();
+
+      expect(spec).toEqual({
+        command: path.join(cacheDir, "demo-acp@1.2.3", "darwin-aarch64", "demo"),
+        args: ["--acp"],
+        env: undefined,
+        kind: "binary",
+      });
+      expect(existsSync(spec.command)).toBe(true);
+      // 0o111 — executable by someone.
+      expect((await stat(spec.command)).mode & 0o111).toBeGreaterThan(0);
+    });
+
+    it("skips the executable bit on Windows, which has none", async () => {
+      const { spec } = await install({ options: { platform: "win32" } });
+
+      expect(existsSync(spec.command)).toBe(true);
+    });
+
+    it("reuses a cached install instead of downloading again", async () => {
+      await install();
+      const { fetchImpl } = await install();
+
+      expect(fetchImpl).not.toHaveBeenCalled();
+      expect(errorSpy.mock.calls.flat().join("\n")).toContain("Using cached demo-acp 1.2.3");
+    });
+
+    it("refuses an archive with no published checksum", async () => {
+      await expect(install({ target: { sha256: undefined } })).rejects.toThrow(
+        /publishes no sha256/,
+      );
+    });
+
+    it("installs an unverified archive when explicitly allowed, and says so", async () => {
+      const { spec } = await install({
+        target: { sha256: undefined },
+        options: { allowUnverified: true },
+      });
+
+      expect(existsSync(spec.command)).toBe(true);
+      expect(errorSpy.mock.calls.flat().join("\n")).toContain("publishes no checksum");
+    });
+
+    it("refuses a download that does not match the checksum", async () => {
+      await expect(install({ target: { sha256: "c".repeat(64) } })).rejects.toThrow(
+        /Checksum mismatch/,
+      );
+    });
+
+    it("leaves nothing cached when the archive lacks the promised command", async () => {
+      await expect(install({ target: { cmd: "./not-in-archive" } })).rejects.toThrow(
+        /does not contain "\.\/not-in-archive"/,
+      );
+      expect(existsSync(installDir(cacheDir, agent.id, "darwin-aarch64", agent.version))).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("resolveAgentLaunch", () => {
+    const gemini: RegistryAgent = {
+      id: "gemini",
+      name: "Gemini CLI",
+      version: "0.58.0",
+      description: "Google's CLI",
+      distribution: { npx: { package: "@google/gemini-cli@0.58.0", args: ["--acp"] } },
+    };
+    const pyAgent: RegistryAgent = {
+      id: "fast-agent",
+      name: "fast-agent",
+      version: "1.0.0",
+      description: "A Python agent",
+      distribution: { uvx: { package: "fast-agent-mcp" } },
+    };
+    const binaryOnly: RegistryAgent = {
+      ...agent,
+      distribution: {
+        binary: {
+          "linux-x86_64": { archive: "https://x/y.tar.gz", sha256: "a".repeat(64), cmd: "./demo" },
+        },
+      },
+    };
+    const registry: Registry = {
+      version: "1.0.0",
+      agents: [gemini, pyAgent, binaryOnly],
+    };
+
+    it("runs npm-distributed agents through npx without downloading anything", async () => {
+      const fetchImpl = vi.fn();
+      const spec = await resolveAgentLaunch({
+        id: "gemini",
+        registry,
+        platformTarget: "darwin-aarch64",
+        fetchImpl: fetchImpl as any,
+      });
+
+      expect(spec).toEqual({
+        command: "npx",
+        args: ["-y", "@google/gemini-cli@0.58.0", "--acp"],
+        env: undefined,
+        kind: "npx",
+      });
+      expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
+    it("names npx explicitly on Windows, where a bare npx cannot be spawned", async () => {
+      const spec = await resolveAgentLaunch({
+        id: "gemini",
+        registry,
+        platformTarget: "windows-x86_64",
+        platform: "win32",
+      });
+
+      expect(spec.command).toBe("npx.cmd");
+    });
+
+    it("runs PyPI-distributed agents through uvx", async () => {
+      const spec = await resolveAgentLaunch({
+        id: "fast-agent",
+        registry,
+        platformTarget: "linux-x86_64",
+      });
+
+      expect(spec).toEqual({
+        command: "uvx",
+        args: ["fast-agent-mcp"],
+        env: undefined,
+        kind: "uvx",
+      });
+    });
+
+    it("installs the binary when that is the only distribution", async () => {
+      const tarball = await makeTarball("demo", "#!/bin/sh\nexit 0\n");
+      const registryWithDigest: Registry = {
+        version: "1.0.0",
+        agents: [
+          {
+            ...binaryOnly,
+            distribution: {
+              binary: {
+                "linux-x86_64": {
+                  archive: "https://x/y.tar.gz",
+                  sha256: sha256(tarball),
+                  cmd: "./demo",
+                },
+              },
+            },
+          },
+        ],
+      };
+      const fetchImpl = vi.fn().mockResolvedValue(okResponse(tarball));
+
+      const spec = await resolveAgentLaunch({
+        id: "demo-acp",
+        registry: registryWithDigest,
+        platformTarget: "linux-x86_64",
+        cacheDir,
+        fetchImpl: fetchImpl as any,
+        platform: "linux",
+      });
+
+      expect(spec.kind).toBe("binary");
+      expect(existsSync(spec.command)).toBe(true);
+    });
+
+    it("reports an id the registry does not list", async () => {
+      await expect(
+        resolveAgentLaunch({ id: "nope", registry, platformTarget: "linux-x86_64" }),
+      ).rejects.toThrow(/No agent "nope" in the ACP registry/);
+    });
+
+    it("reports an agent that has no build for this machine", async () => {
+      await expect(
+        resolveAgentLaunch({ id: "demo-acp", registry, platformTarget: "windows-aarch64" }),
+      ).rejects.toThrow(/publishes no build of "demo-acp" for windows-aarch64 \(it publishes: binary\)/);
+    });
+
+    it("says so when an agent publishes no distribution at all", async () => {
+      const empty: Registry = {
+        version: "1.0.0",
+        agents: [{ ...agent, distribution: {} }],
+      };
+
+      await expect(
+        resolveAgentLaunch({ id: "demo-acp", registry: empty, platformTarget: "linux-x86_64" }),
+      ).rejects.toThrow(/it publishes: nothing/);
+    });
+
+    it("reports an unsupported platform by name", async () => {
+      await expect(
+        resolveAgentLaunch({ id: "demo-acp", registry, platformTarget: undefined }),
+      ).rejects.toThrow(/publishes no build of "demo-acp" for/);
+    });
+  });
+});

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -14,7 +14,9 @@ import {
   isInteractiveTerminal,
   openAgentConnection,
   parseGatewayArgs,
+  assertAgentRunnable,
   helpText,
+  isRunnable,
   printHelp,
   resolveAgentCommand,
   runListAgents,
@@ -643,6 +645,48 @@ describe("index", () => {
     it("should recognise both spellings of the help flag", () => {
       expect(parseGatewayArgs(["--help"]).command).toBe("help");
       expect(parseGatewayArgs(["-h"]).command).toBe("help");
+    });
+  });
+
+  describe("isRunnable", () => {
+    it("finds a command on PATH", () => {
+      expect(isRunnable("node", { PATH: process.env.PATH }, process.platform)).toBe(true);
+    });
+
+    it("does not find one that is not there", () => {
+      expect(isRunnable("acp-gateway-no-such-command", { PATH: process.env.PATH })).toBe(false);
+      expect(isRunnable("node", { PATH: "" })).toBe(false);
+      expect(isRunnable("node", {})).toBe(false);
+    });
+
+    it("checks a path directly rather than searching PATH", () => {
+      expect(isRunnable(process.execPath, {})).toBe(true);
+      expect(isRunnable("/no/such/agent", {})).toBe(false);
+    });
+
+    it("honours PATHEXT and backslashes on Windows", () => {
+      // A bare name on Windows resolves through PATHEXT, so "npx" alone finds
+      // nothing while "npx.cmd" would.
+      expect(isRunnable("npx", { PATH: "C:\\tools", PATHEXT: ".EXE" }, "win32")).toBe(false);
+      expect(isRunnable("C:\\nope\\agent.exe", {}, "win32")).toBe(false);
+    });
+  });
+
+  describe("assertAgentRunnable", () => {
+    it("accepts a command that exists", () => {
+      expect(() => assertAgentRunnable("node", false)).not.toThrow();
+    });
+
+    it("suggests --agent when the command looks like a registry id", () => {
+      expect(() => assertAgentRunnable("antigravity-acp", false)).toThrow(
+        /run it with --agent antigravity-acp/,
+      );
+    });
+
+    it("blames the registry when the id was already resolved", () => {
+      expect(() => assertAgentRunnable("acp-gateway-no-such-runner", true)).toThrow(
+        /The registry says to run it as "acp-gateway-no-such-runner", which is not installed/,
+      );
     });
   });
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -14,7 +14,8 @@ import {
   isInteractiveTerminal,
   openAgentConnection,
   parseGatewayArgs,
-  printUsage,
+  helpText,
+  printHelp,
   resolveAgentCommand,
   runListAgents,
   pickHumanApprovalMode,
@@ -638,6 +639,11 @@ describe("index", () => {
       ).toBe("http://localhost/registry.json");
       expect(parseGatewayArgs(["--registry-url"]).registryUrl).toBeUndefined();
     });
+
+    it("should recognise both spellings of the help flag", () => {
+      expect(parseGatewayArgs(["--help"]).command).toBe("help");
+      expect(parseGatewayArgs(["-h"]).command).toBe("help");
+    });
   });
 
   describe("runListAgents", () => {
@@ -819,17 +825,52 @@ describe("index", () => {
     });
   });
 
-  describe("printUsage", () => {
-    it("should document the auth commands alongside the bridge usage", () => {
+  describe("helpText", () => {
+    it("should explain every option the parser accepts", () => {
+      const text = helpText("9.9.9");
+
+      // Every documented flag must be one parseGatewayArgs actually handles,
+      // and every flag it handles must be documented.
+      const documented = [...text.matchAll(/^\s{2}(--[a-z-]+|-h)/gm)].map((m) => m[1]);
+      expect(new Set(documented)).toEqual(
+        new Set([
+          "--agent",
+          "--list-agents",
+          "--allow-unverified-agent",
+          "--registry-url",
+          "--list-auth-methods",
+          "--login",
+          "--logout",
+          "--auth-method",
+          "--max-concurrency",
+          "--help",
+        ]),
+      );
+    });
+
+    it("should name the version and show how to run an agent both ways", () => {
+      const text = helpText("9.9.9");
+
+      expect(text).toContain("acp-gateway 9.9.9");
+      expect(text).toContain("acp-gateway --agent gemini");
+      expect(text).toContain("acp-gateway -- gemini --acp");
+      expect(text).toContain(".mcp.json");
+    });
+
+    it("should say why an unverified agent is not installed by default", () => {
+      expect(helpText()).toMatch(/no way to tell what was downloaded/);
+    });
+  });
+
+  describe("printHelp", () => {
+    it("should print the help text", () => {
       const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-      printUsage();
+      printHelp();
       const printed = logSpy.mock.calls.flat().join("\n");
       logSpy.mockRestore();
 
-      expect(printed).toContain("--list-auth-methods");
-      expect(printed).toContain("--login [method-id]");
-      expect(printed).toContain("--logout");
-      expect(printed).toContain("--auth-method <id>");
+      expect(printed).toContain("USAGE");
+      expect(printed).toContain("--list-agents");
     });
   });
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -15,6 +15,8 @@ import {
   openAgentConnection,
   parseGatewayArgs,
   printUsage,
+  resolveAgentCommand,
+  runListAgents,
   pickHumanApprovalMode,
   enforceHumanApprovalMode,
   runAuthCommand,
@@ -568,7 +570,12 @@ describe("index", () => {
 
   describe("parseGatewayArgs", () => {
     it("should default to bridging tasks with a concurrency of 2", () => {
-      expect(parseGatewayArgs([])).toEqual({ maxConcurrency: 2, command: "run" });
+      expect(parseGatewayArgs([])).toEqual({
+        maxConcurrency: 2,
+        command: "run",
+        allowUnverifiedAgent: false,
+        rest: [],
+      });
     });
 
     it("should accept both spellings of the concurrency flag", () => {
@@ -579,14 +586,14 @@ describe("index", () => {
     it("should keep the default when the concurrency value is missing or not a number", () => {
       expect(parseGatewayArgs(["--max-concurrency"]).maxConcurrency).toBe(2);
       expect(parseGatewayArgs(["--max-concurrency", "many"]).maxConcurrency).toBe(2);
-      expect(parseGatewayArgs(["--max-concurrency", "--logout"])).toEqual({
+      expect(parseGatewayArgs(["--max-concurrency", "--logout"])).toMatchObject({
         maxConcurrency: 2,
         command: "logout",
       });
     });
 
     it("should read the preferred auth method", () => {
-      expect(parseGatewayArgs(["--auth-method", "oauth"])).toEqual({
+      expect(parseGatewayArgs(["--auth-method", "oauth"])).toMatchObject({
         maxConcurrency: 2,
         command: "run",
         authMethodId: "oauth",
@@ -595,8 +602,8 @@ describe("index", () => {
     });
 
     it("should recognise the auth commands", () => {
-      expect(parseGatewayArgs(["--login"])).toEqual({ maxConcurrency: 2, command: "login" });
-      expect(parseGatewayArgs(["--login", "oauth"])).toEqual({
+      expect(parseGatewayArgs(["--login"])).toMatchObject({ maxConcurrency: 2, command: "login" });
+      expect(parseGatewayArgs(["--login", "oauth"])).toMatchObject({
         maxConcurrency: 2,
         command: "login",
         authMethodId: "oauth",
@@ -605,8 +612,131 @@ describe("index", () => {
       expect(parseGatewayArgs(["--list-auth-methods"]).command).toBe("list-auth-methods");
     });
 
-    it("should ignore flags it does not know", () => {
-      expect(parseGatewayArgs(["--verbose", "--login"]).command).toBe("login");
+    it("should keep tokens it does not recognise as the agent command", () => {
+      const options = parseGatewayArgs(["--verbose", "--login"]);
+      expect(options.command).toBe("login");
+      expect(options.rest).toEqual(["--verbose"]);
+    });
+
+    it("should collect an agent command given without a -- separator", () => {
+      expect(parseGatewayArgs(["--max-concurrency", "4", "gemini", "--acp"])).toMatchObject({
+        maxConcurrency: 4,
+        rest: ["gemini", "--acp"],
+      });
+    });
+
+    it("should read the registry options", () => {
+      expect(parseGatewayArgs(["--agent", "gemini"])).toMatchObject({
+        agentId: "gemini",
+        command: "run",
+      });
+      expect(parseGatewayArgs(["--agent"]).agentId).toBeUndefined();
+      expect(parseGatewayArgs(["--list-agents"]).command).toBe("list-agents");
+      expect(parseGatewayArgs(["--allow-unverified-agent"]).allowUnverifiedAgent).toBe(true);
+      expect(
+        parseGatewayArgs(["--registry-url", "http://localhost/registry.json"]).registryUrl,
+      ).toBe("http://localhost/registry.json");
+      expect(parseGatewayArgs(["--registry-url"]).registryUrl).toBeUndefined();
+    });
+  });
+
+  describe("runListAgents", () => {
+    const registry = {
+      version: "1.0.0",
+      agents: [
+        {
+          id: "gemini",
+          name: "Gemini CLI",
+          version: "0.58.0",
+          description: "Google's CLI",
+          distribution: { npx: { package: "@google/gemini-cli", args: ["--acp"] } },
+        },
+      ],
+    };
+
+    it("should print every agent and how to run one", async () => {
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const fetchImpl = vi.fn().mockResolvedValue({ ok: true, json: async () => registry });
+
+      await runListAgents(undefined, fetchImpl as any);
+
+      const printed = logSpy.mock.calls.flat().join("\n");
+      logSpy.mockRestore();
+      expect(printed).toContain("ACP registry v1.0.0 — 1 agents");
+      expect(printed).toContain("gemini");
+      expect(printed).toContain("acp-gateway --agent <id>");
+    });
+
+    it("should read a registry the user pointed it at", async () => {
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const fetchImpl = vi.fn().mockResolvedValue({ ok: true, json: async () => registry });
+
+      await runListAgents("http://localhost/registry.json", fetchImpl as any);
+      logSpy.mockRestore();
+
+      expect(fetchImpl).toHaveBeenCalledWith("http://localhost/registry.json");
+    });
+  });
+
+  describe("resolveAgentCommand", () => {
+    const options = (overrides: Record<string, any> = {}) => ({
+      maxConcurrency: 2,
+      command: "run" as const,
+      allowUnverifiedAgent: false,
+      rest: [],
+      ...overrides,
+    });
+
+    it("should use the command given after -- when no registry id was named", async () => {
+      const fetchImpl = vi.fn();
+
+      const resolved = await resolveAgentCommand(options(), ["gemini", "--acp"], fetchImpl as any);
+
+      expect(resolved).toEqual({ command: ["gemini", "--acp"] });
+      expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
+    it("should resolve a registry id into the command that runs it", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const fetchImpl = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          version: "1.0.0",
+          agents: [
+            {
+              id: "gemini",
+              name: "Gemini CLI",
+              version: "0.58.0",
+              description: "Google's CLI",
+              distribution: {
+                npx: { package: "@google/gemini-cli@0.58.0", args: ["--acp"], env: { K: "v" } },
+              },
+            },
+          ],
+        }),
+      });
+
+      const resolved = await resolveAgentCommand(
+        options({ agentId: "gemini" }),
+        [],
+        fetchImpl as any,
+      );
+      errorSpy.mockRestore();
+
+      expect(resolved.command[0]).toMatch(/^npx/);
+      expect(resolved.command.slice(1)).toEqual(["-y", "@google/gemini-cli@0.58.0", "--acp"]);
+      expect(resolved.env).toEqual({ K: "v" });
+    });
+
+    it("should surface a registry id that does not exist", async () => {
+      const fetchImpl = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ version: "1.0.0", agents: [] }),
+      });
+
+      await expect(
+        resolveAgentCommand(options({ agentId: "nope" }), [], fetchImpl as any),
+      ).rejects.toThrow(/No agent "nope" in the ACP registry/);
     });
   });
 

--- a/src/__tests__/registry.test.ts
+++ b/src/__tests__/registry.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  DEFAULT_REGISTRY_URL,
+  availableKinds,
+  describeAgents,
+  fetchRegistry,
+  findAgent,
+  hostPlatformTarget,
+  packageLaunchSpec,
+  selectBinaryTarget,
+  type Registry,
+  type RegistryAgent,
+} from "../registry.js";
+
+const gemini: RegistryAgent = {
+  id: "gemini",
+  name: "Gemini CLI",
+  version: "0.58.0",
+  description: "Google's official CLI for Gemini",
+  distribution: {
+    npx: { package: "@google/gemini-cli@0.58.0", args: ["--acp"] },
+  },
+};
+
+const antigravity: RegistryAgent = {
+  id: "antigravity-acp",
+  name: "Google Antigravity",
+  version: "1.0.0",
+  description: "Google's AI coding agent",
+  distribution: {
+    binary: {
+      "darwin-aarch64": {
+        archive: "https://dl.google.com/agy/darwin-arm64.zip",
+        cmd: "./agy_acp_server.par",
+      },
+      "linux-x86_64": {
+        archive: "https://dl.google.com/agy/linux-x86_64.zip",
+        sha256: "a".repeat(64),
+        cmd: "./agy_acp_server.par",
+        args: ["--uid="],
+      },
+    },
+  },
+};
+
+const fastAgent: RegistryAgent = {
+  id: "fast-agent",
+  name: "fast-agent",
+  version: "1.0.0",
+  description: "A Python agent",
+  distribution: { uvx: { package: "fast-agent-mcp", args: ["serve"] } },
+};
+
+const registry: Registry = {
+  version: "1.0.0",
+  agents: [gemini, antigravity, fastAgent],
+};
+
+function jsonResponse(body: unknown, init: Partial<Response> = {}) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => body,
+    ...init,
+  } as Response;
+}
+
+describe("registry", () => {
+  describe("hostPlatformTarget", () => {
+    it("maps Node's platform and arch onto the registry's identifiers", () => {
+      expect(hostPlatformTarget("darwin", "arm64")).toBe("darwin-aarch64");
+      expect(hostPlatformTarget("darwin", "x64")).toBe("darwin-x86_64");
+      expect(hostPlatformTarget("linux", "arm64")).toBe("linux-aarch64");
+      expect(hostPlatformTarget("linux", "x64")).toBe("linux-x86_64");
+      expect(hostPlatformTarget("win32", "x64")).toBe("windows-x86_64");
+      expect(hostPlatformTarget("win32", "arm64")).toBe("windows-aarch64");
+    });
+
+    it("returns nothing for platforms the registry does not publish for", () => {
+      expect(hostPlatformTarget("freebsd", "x64")).toBeUndefined();
+      expect(hostPlatformTarget("linux", "ppc64")).toBeUndefined();
+    });
+
+    it("describes the machine it is running on by default", () => {
+      // Every platform this package supports is one the registry publishes for.
+      expect(hostPlatformTarget()).toMatch(/^(darwin|linux|windows)-(aarch64|x86_64)$/);
+    });
+  });
+
+  describe("fetchRegistry", () => {
+    it("fetches the published index by default", async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(registry));
+
+      expect(await fetchRegistry(undefined, fetchImpl as any)).toEqual(registry);
+      expect(fetchImpl).toHaveBeenCalledWith(DEFAULT_REGISTRY_URL);
+    });
+
+    it("accepts a different registry so a local copy can be used", async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(registry));
+
+      await fetchRegistry("http://localhost:9000/registry.json", fetchImpl as any);
+
+      expect(fetchImpl).toHaveBeenCalledWith("http://localhost:9000/registry.json");
+    });
+
+    it("reports a failed request", async () => {
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValue({ ok: false, status: 404, statusText: "Not Found" });
+
+      await expect(fetchRegistry(DEFAULT_REGISTRY_URL, fetchImpl as any)).rejects.toThrow(
+        /404 Not Found/,
+      );
+    });
+
+    it("rejects a response that is not a registry index", async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ nope: true }));
+
+      await expect(fetchRegistry(DEFAULT_REGISTRY_URL, fetchImpl as any)).rejects.toThrow(
+        /did not return an ACP registry index/,
+      );
+    });
+  });
+
+  describe("findAgent", () => {
+    it("finds an agent by id", () => {
+      expect(findAgent(registry, "gemini")).toBe(gemini);
+    });
+
+    it("returns nothing for an unknown id", () => {
+      expect(findAgent(registry, "nope")).toBeUndefined();
+    });
+  });
+
+  describe("availableKinds", () => {
+    it("lists the distributions that can run here", () => {
+      expect(availableKinds(gemini, "darwin-aarch64")).toEqual(["npx"]);
+      expect(availableKinds(fastAgent, "darwin-aarch64")).toEqual(["uvx"]);
+      expect(availableKinds(antigravity, "darwin-aarch64")).toEqual(["binary"]);
+    });
+
+    it("omits a binary the registry does not publish for this platform", () => {
+      expect(availableKinds(antigravity, "windows-aarch64")).toEqual([]);
+      expect(availableKinds(antigravity, undefined)).toEqual([]);
+    });
+
+    it("lists every distribution an agent offers", () => {
+      const both: RegistryAgent = {
+        ...gemini,
+        distribution: { ...gemini.distribution, binary: antigravity.distribution.binary },
+      };
+      expect(availableKinds(both, "darwin-aarch64")).toEqual(["npx", "binary"]);
+    });
+  });
+
+  describe("describeAgents", () => {
+    it("lists every agent with how it can be run here", () => {
+      const text = describeAgents(registry, "darwin-aarch64");
+      expect(text).toContain("gemini");
+      expect(text).toContain("Gemini CLI — npx");
+      expect(text).toContain("fast-agent");
+    });
+
+    it("says when an agent cannot run on this machine", () => {
+      const unavailable: Registry = {
+        version: "1.0.0",
+        agents: [{ ...antigravity, distribution: { binary: {} } }],
+      };
+      expect(describeAgents(unavailable, "darwin-aarch64")).toContain("unavailable on this platform");
+    });
+  });
+
+  describe("selectBinaryTarget", () => {
+    it("picks the build for this machine", () => {
+      expect(selectBinaryTarget(antigravity, "linux-x86_64").args).toEqual(["--uid="]);
+    });
+
+    it("refuses an agent that ships no binaries", () => {
+      expect(() => selectBinaryTarget(gemini, "darwin-aarch64")).toThrow(
+        /publishes no binary distribution/,
+      );
+    });
+
+    it("refuses a platform the registry does not cover", () => {
+      expect(() => selectBinaryTarget(antigravity, undefined)).toThrow(
+        /registry publishes no binaries for/,
+      );
+    });
+
+    it("refuses to substitute another platform's build", () => {
+      expect(() => selectBinaryTarget(antigravity, "windows-x86_64")).toThrow(
+        /no binary for windows-x86_64 \(available: darwin-aarch64, linux-x86_64\)/,
+      );
+    });
+  });
+
+  describe("packageLaunchSpec", () => {
+    it("runs npm packages through npx without prompting", () => {
+      expect(packageLaunchSpec("npx", gemini.distribution.npx!)).toEqual({
+        command: "npx",
+        args: ["-y", "@google/gemini-cli@0.58.0", "--acp"],
+        env: undefined,
+        kind: "npx",
+      });
+    });
+
+    it("runs PyPI packages through uvx", () => {
+      expect(packageLaunchSpec("uvx", fastAgent.distribution.uvx!)).toEqual({
+        command: "uvx",
+        args: ["fast-agent-mcp", "serve"],
+        env: undefined,
+        kind: "uvx",
+      });
+    });
+
+    it("passes the distribution's env through and tolerates missing args", () => {
+      expect(packageLaunchSpec("npx", { package: "some-agent", env: { KEY: "v" } })).toEqual({
+        command: "npx",
+        args: ["-y", "some-agent"],
+        env: { KEY: "v" },
+        kind: "npx",
+      });
+    });
+  });
+});

--- a/src/agentInstall.ts
+++ b/src/agentInstall.ts
@@ -1,0 +1,340 @@
+/**
+ * agentInstall.ts
+ *
+ * Downloads, verifies and unpacks the binary distribution of a registry agent,
+ * caching it so the download happens once.
+ *
+ * This is the one place in the gateway that fetches a third-party executable
+ * and runs it, so the rules here are deliberately strict: an archive is only
+ * installed when the registry publishes a `sha256` that the download matches,
+ * unless the user has explicitly said otherwise.
+ */
+
+import { createHash } from "node:crypto";
+import { spawn } from "node:child_process";
+import { chmod, cp, mkdir, mkdtemp, rename, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import * as path from "node:path";
+import {
+  availableKinds,
+  findAgent,
+  packageLaunchSpec,
+  selectBinaryTarget,
+  type BinaryTarget,
+  type LaunchSpec,
+  type PlatformTarget,
+  type Registry,
+  type RegistryAgent,
+} from "./registry.js";
+
+/**
+ * Where downloaded agents live, unless overridden.
+ *
+ * Follows each platform's own convention: `%LOCALAPPDATA%` on Windows,
+ * `XDG_CACHE_HOME` where it is set, and `~/.cache` otherwise.
+ */
+export function defaultCacheDir(
+  platform: string = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const base =
+    platform === "win32"
+      ? env.LOCALAPPDATA || path.join(homedir(), "AppData", "Local")
+      : env.XDG_CACHE_HOME || path.join(homedir(), ".cache");
+  return path.join(base, "acp-gateway", "agents");
+}
+
+/** Archive shapes the registry allows, mapped to how they are unpacked. */
+export type ArchiveKind = "zip" | "tar.gz" | "tar.bz2" | "raw";
+
+/**
+ * Classifies an archive by its URL.
+ *
+ * The registry documents exactly which formats may appear; anything else is a
+ * raw executable to be saved as-is.
+ */
+export function archiveKind(url: string): ArchiveKind {
+  const pathname = url.split("?")[0].split("#")[0].toLowerCase();
+  if (pathname.endsWith(".zip")) return "zip";
+  if (pathname.endsWith(".tar.gz") || pathname.endsWith(".tgz")) return "tar.gz";
+  if (pathname.endsWith(".tar.bz2") || pathname.endsWith(".tbz2")) return "tar.bz2";
+  return "raw";
+}
+
+/** The directory one agent build is unpacked into. */
+export function installDir(cacheDir: string, agentId: string, target: PlatformTarget, version: string): string {
+  // The version is part of the path so a registry bump installs alongside the
+  // old build rather than half-overwriting it.
+  return path.join(cacheDir, `${agentId}@${version}`, target);
+}
+
+/**
+ * Resolves the registry's `cmd` inside the install directory.
+ *
+ * `cmd` is third-party text, so a path that climbs out of the directory — and
+ * would have us run something else entirely — is rejected rather than resolved.
+ */
+export function resolveExecutable(dir: string, cmd: string): string {
+  const executable = path.resolve(dir, cmd);
+  const root = path.resolve(dir);
+  if (executable !== root && !executable.startsWith(root + path.sep)) {
+    throw new Error(`Agent command "${cmd}" points outside its install directory; refusing to run it.`);
+  }
+  return executable;
+}
+
+export function sha256(data: Uint8Array): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+/**
+ * Refuses an archive we cannot vouch for.
+ *
+ * Roughly half the registry's binary targets publish no checksum. Running one
+ * means trusting whatever the vendor's host served, so it takes an explicit
+ * opt-in rather than happening quietly.
+ */
+export function assertVerifiable(
+  agent: RegistryAgent,
+  target: BinaryTarget,
+  allowUnverified: boolean,
+): void {
+  if (target.sha256 || allowUnverified) return;
+  throw new Error(
+    `The ACP registry publishes no sha256 for "${agent.id}" on this platform, so the ` +
+      `download cannot be verified. Re-run with --allow-unverified-agent to install it anyway, ` +
+      `or install the agent yourself and pass it after --.`,
+  );
+}
+
+/** Checks a download against the registry's checksum. */
+export function assertChecksum(agent: RegistryAgent, target: BinaryTarget, data: Uint8Array): void {
+  if (!target.sha256) return;
+  const actual = sha256(data);
+  if (actual.toLowerCase() !== target.sha256.toLowerCase()) {
+    throw new Error(
+      `Checksum mismatch for "${agent.id}": the registry expects ${target.sha256.toLowerCase()} ` +
+        `but ${target.archive} produced ${actual}. Refusing to run it.`,
+    );
+  }
+}
+
+/** Downloads an archive into memory so it can be checksummed before it touches disk. */
+export async function downloadArchive(
+  url: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Uint8Array> {
+  const response = await fetchImpl(url);
+  if (!response.ok) {
+    throw new Error(`Failed to download ${url}: ${response.status} ${response.statusText}`);
+  }
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+/** Runs an extraction tool, failing with its own diagnostics attached. */
+export async function runExtractionTool(
+  command: string,
+  args: string[],
+  cwd: string,
+): Promise<void> {
+  const child = spawn(command, args, { cwd, stdio: ["ignore", "ignore", "pipe"] });
+  let stderr = "";
+  child.stderr?.on("data", (chunk: Buffer) => {
+    stderr += chunk.toString();
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    child.on("error", (err: Error) =>
+      reject(
+        new Error(
+          `Could not run "${command}" to unpack the agent archive: ${err.message}. ` +
+            `Install it, or install the agent yourself and pass it after --.`,
+        ),
+      ),
+    );
+    child.on("exit", (code: number | null) => {
+      if (code === 0) return resolve();
+      reject(new Error(`"${command}" failed to unpack the agent archive (code=${code}): ${stderr.trim()}`));
+    });
+  });
+}
+
+/**
+ * Unpacks an archive into `dir`.
+ *
+ * Uses the system's own tools rather than adding archive libraries as
+ * dependencies. `tar` handles the tarballs everywhere and zips on macOS and
+ * Windows, where it is bsdtar; GNU tar cannot read zips, so Linux falls back
+ * to `unzip`.
+ */
+export async function extractArchive(
+  data: Uint8Array,
+  kind: ArchiveKind,
+  dir: string,
+  cmd: string,
+  platform: string = process.platform,
+): Promise<void> {
+  await mkdir(dir, { recursive: true });
+
+  if (kind === "raw") {
+    // No archive to unpack: the download is the executable itself.
+    await writeFile(path.join(dir, path.basename(cmd)), data);
+    return;
+  }
+
+  const archivePath = path.join(dir, `archive.${kind}`);
+  await writeFile(archivePath, data);
+  try {
+    if (kind === "zip" && platform === "linux") {
+      await runExtractionTool("unzip", ["-q", "-o", archivePath], dir);
+    } else {
+      await runExtractionTool("tar", ["-xf", archivePath], dir);
+    }
+  } finally {
+    await rm(archivePath, { force: true });
+  }
+}
+
+export interface InstallOptions {
+  agent: RegistryAgent;
+  target: BinaryTarget;
+  platformTarget: PlatformTarget;
+  cacheDir?: string;
+  /** Install an archive the registry publishes no checksum for. */
+  allowUnverified?: boolean;
+  fetchImpl?: typeof fetch;
+  platform?: string;
+}
+
+/**
+ * Makes a registry agent runnable, returning the command that launches it.
+ *
+ * A cached install is reused as-is; the version in the cache path means a
+ * registry bump installs a fresh copy rather than reusing a stale one.
+ */
+export async function installBinaryAgent({
+  agent,
+  target,
+  platformTarget,
+  cacheDir,
+  allowUnverified = false,
+  fetchImpl = fetch,
+  platform = process.platform,
+}: InstallOptions): Promise<LaunchSpec> {
+  cacheDir ??= defaultCacheDir(platform);
+  const dir = installDir(cacheDir, agent.id, platformTarget, agent.version);
+  const executable = resolveExecutable(dir, target.cmd);
+  const spec: LaunchSpec = {
+    command: executable,
+    args: target.args ?? [],
+    env: target.env,
+    kind: "binary",
+  };
+
+  if (existsSync(executable)) {
+    console.error(`[registry] Using cached ${agent.id} ${agent.version} from ${dir}`);
+    return spec;
+  }
+
+  assertVerifiable(agent, target, allowUnverified);
+
+  console.error(`[registry] Downloading ${agent.id} ${agent.version} from ${target.archive}`);
+  const data = await downloadArchive(target.archive, fetchImpl);
+  assertChecksum(agent, target, data);
+  if (!target.sha256) {
+    console.error(
+      `[registry] ⚠️  ${agent.id} publishes no checksum; installing it unverified at your request.`,
+    );
+  }
+
+  // Unpack somewhere temporary and move into place only once it succeeded, so
+  // a failed extraction never leaves a half-installed agent to be cached.
+  const staging = await mkdtemp(path.join(tmpdir(), `acp-gateway-${agent.id}-`));
+  try {
+    await extractArchive(data, archiveKind(target.archive), staging, target.cmd, platform);
+    const staged = resolveExecutable(staging, target.cmd);
+    if (!existsSync(staged)) {
+      throw new Error(
+        `The archive for "${agent.id}" does not contain "${target.cmd}" where the registry says it should.`,
+      );
+    }
+    await rm(dir, { recursive: true, force: true });
+    await mkdir(path.dirname(dir), { recursive: true });
+    await moveInto(staging, dir);
+  } finally {
+    await rm(staging, { recursive: true, force: true });
+  }
+
+  // Archive formats do not always carry the executable bit. Windows has no
+  // such bit — chmod there only toggles the read-only flag — so skip it.
+  if (platform !== "win32") {
+    await chmod(executable, 0o755);
+  }
+  console.error(`[registry] Installed ${agent.id} ${agent.version} to ${dir}`);
+  return spec;
+}
+
+/** Moves a staged install into the cache, copying across filesystems if needed. */
+export async function moveInto(from: string, to: string): Promise<void> {
+  try {
+    await rename(from, to);
+  } catch {
+    // rename() fails across devices — the temp dir is often a different mount.
+    await cp(from, to, { recursive: true });
+  }
+}
+
+export interface ResolveAgentOptions {
+  id: string;
+  registry: Registry;
+  platformTarget: PlatformTarget | undefined;
+  cacheDir?: string;
+  allowUnverified?: boolean;
+  fetchImpl?: typeof fetch;
+  platform?: string;
+}
+
+/**
+ * Turns a registry id into the command that runs that agent, installing it
+ * first where the only distribution is a binary.
+ *
+ * Package distributions are preferred over binaries: npm and PyPI verify what
+ * they serve, and nothing has to be downloaded, unpacked or cached here.
+ */
+export async function resolveAgentLaunch({
+  id,
+  registry,
+  platformTarget,
+  cacheDir,
+  allowUnverified = false,
+  fetchImpl = fetch,
+  platform = process.platform,
+}: ResolveAgentOptions): Promise<LaunchSpec> {
+  const agent = findAgent(registry, id);
+  if (!agent) {
+    throw new Error(`No agent "${id}" in the ACP registry. Run --list-agents to see what it publishes.`);
+  }
+
+  const kinds = availableKinds(agent, platformTarget);
+  if (!kinds.length) {
+    const published = Object.keys(agent.distribution).join(", ") || "nothing";
+    throw new Error(
+      `The ACP registry publishes no build of "${id}" for ${platformTarget ?? `${process.platform}/${process.arch}`} ` +
+        `(it publishes: ${published}).`,
+    );
+  }
+
+  if (kinds.includes("npx")) return packageLaunchSpec("npx", agent.distribution.npx!, platform);
+  if (kinds.includes("uvx")) return packageLaunchSpec("uvx", agent.distribution.uvx!, platform);
+
+  return installBinaryAgent({
+    agent,
+    target: selectBinaryTarget(agent, platformTarget),
+    platformTarget: platformTarget!,
+    cacheDir,
+    allowUnverified,
+    fetchImpl,
+    platform,
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -431,7 +431,8 @@ export type GatewayCommand =
   | "login"
   | "logout"
   | "list-auth-methods"
-  | "list-agents";
+  | "list-agents"
+  | "help";
 
 export interface GatewayOptions {
   maxConcurrency: number;
@@ -511,6 +512,10 @@ export function parseGatewayArgs(args: string[]): GatewayOptions {
           options.registryUrl = value;
           i++;
         }
+        break;
+      case "--help":
+      case "-h":
+        options.command = "help";
         break;
       default:
         // Anything unrecognised belongs to the agent command, which may be
@@ -619,22 +624,65 @@ export async function runAuthCommand(
   }
 }
 
-export function printUsage(): void {
-  console.log(
-    "Usage: acp-gateway [--max-concurrency <number>] [--auth-method <id>] -- <acp-server-command> [args...]",
-  );
-  console.log("       acp-gateway --agent <registry-id> [--allow-unverified-agent]");
-  console.log("       acp-gateway --list-agents");
-  console.log("       acp-gateway --list-auth-methods -- <acp-server-command> [args...]");
-  console.log("       acp-gateway --login [method-id] -- <acp-server-command> [args...]");
-  console.log("       acp-gateway --logout -- <acp-server-command> [args...]");
-  console.log("Example: acp-gateway --max-concurrency 4 -- gemini --acp");
-  console.log("Example: acp-gateway --agent gemini");
+/**
+ * The full help text.
+ *
+ * Shown for `--help`, and when the gateway is run with nothing to do — at
+ * which point the reason someone is looking at the terminal is that they do
+ * not yet know what to type.
+ */
+export function helpText(version: string = pkg.version): string {
+  return `acp-gateway ${version} — bridges an ACP agent to an agentrq workspace.
+
+USAGE
+  acp-gateway [options] -- <agent-command> [agent-args...]
+  acp-gateway [options] --agent <registry-id>
+
+  The agent is either a command you supply after \`--\`, or an id from the ACP
+  registry. Everything after \`--\` is passed to the agent untouched.
+
+AGENT
+  --agent <registry-id>       Run an agent from the ACP registry, installing it
+                              if needed, instead of a command you supply.
+  --list-agents               List every agent in the registry, and how each one
+                              can run on this machine. Exits.
+  --allow-unverified-agent    Install a registry binary that publishes no
+                              checksum. Off by default: without a checksum there
+                              is no way to tell what was downloaded.
+  --registry-url <url>        Read a different registry index, for pinning it or
+                              for testing.
+
+AUTHENTICATION
+  --list-auth-methods         List the login methods the agent offers. Exits.
+  --login [method-id]         Log in to the agent. With no id, and a terminal to
+                              ask in, you are asked which method to use. Exits.
+  --logout                    Log out of the agent, where it supports it. Exits.
+  --auth-method <id>          The method to use when the agent demands a login
+                              mid-run. Defaults to choosing one automatically.
+
+BRIDGE
+  --max-concurrency <number>  How many tasks may prompt the agent at once.
+                              Defaults to 2.
+
+OTHER
+  --help, -h                  Show this help. Exits.
+
+EXAMPLES
+  acp-gateway --agent gemini                     Run Gemini from the registry
+  acp-gateway -- gemini --acp                    Run an agent you installed
+  acp-gateway --list-agents                      See what the registry offers
+  acp-gateway --login -- gemini --acp            Log in before running anything
+  acp-gateway --max-concurrency 4 -- gemini --acp
+
+The workspace comes from .mcp.json, searched for in the current directory and up
+to three directories above it.`;
+}
+
+export function printHelp(): void {
+  console.log(helpText());
 }
 
 async function main() {
-  console.log(`Starting [acp-gateway] ${pkg.name} v${pkg.version}`);
-
   const args = process.argv.slice(2);
 
   // Everything after `--` is the agent command. Without a separator the
@@ -648,11 +696,26 @@ async function main() {
 
   const { maxConcurrency, command, authMethodId } = options;
 
+  if (command === "help") {
+    printHelp();
+    process.exit(0);
+  }
+
   // Listing the registry needs neither a workspace nor an agent.
   if (command === "list-agents") {
     await runListAgents(options.registryUrl);
     process.exit(0);
   }
+
+  // Nothing to run: the reason someone is looking at the terminal now is that
+  // they do not yet know what to type, so show the help rather than an error
+  // about a workspace they have not got to yet.
+  if (!options.agentId && explicitCommand.length === 0) {
+    printHelp();
+    process.exit(1);
+  }
+
+  console.log(`Starting [acp-gateway] ${pkg.name} v${pkg.version}`);
 
   // 1. Load MCP Config
   const configs = loadMcpConfig();
@@ -662,10 +725,6 @@ async function main() {
   // the user gave.
   const resolved = await resolveAgentCommand(options, explicitCommand);
   const acpCmdArgs = resolved.command;
-  if (acpCmdArgs.length === 0) {
-    printUsage();
-    process.exit(1);
-  }
   if (resolved.env) {
     // The registry entry's env is part of how that agent must be launched, so
     // it travels with the command into every session spawned from it.

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,12 @@ import {
   type AuthConnection,
   type LoginOptions,
 } from "./auth.js";
+import { resolveAgentLaunch } from "./agentInstall.js";
+import {
+  describeAgents,
+  fetchRegistry,
+  hostPlatformTarget,
+} from "./registry.js";
 import {
   extractTaskIdFromMeta,
   extractTaskIdFromText,
@@ -420,12 +426,25 @@ export class TaskQueue {
 }
 
 /** What the gateway was asked to do, beyond bridging tasks. */
-export type GatewayCommand = "run" | "login" | "logout" | "list-auth-methods";
+export type GatewayCommand =
+  | "run"
+  | "login"
+  | "logout"
+  | "list-auth-methods"
+  | "list-agents";
 
 export interface GatewayOptions {
   maxConcurrency: number;
   authMethodId?: string;
   command: GatewayCommand;
+  /** Registry id of the agent to run, instead of a command given after `--`. */
+  agentId?: string;
+  /** Install a registry binary the registry publishes no checksum for. */
+  allowUnverifiedAgent: boolean;
+  /** A different registry index, for pinning or for testing. */
+  registryUrl?: string;
+  /** Tokens that are not gateway options — the agent command, when no `--` was used. */
+  rest: string[];
 }
 
 /**
@@ -433,7 +452,12 @@ export interface GatewayOptions {
  * the agent command.
  */
 export function parseGatewayArgs(args: string[]): GatewayOptions {
-  const options: GatewayOptions = { maxConcurrency: 2, command: "run" };
+  const options: GatewayOptions = {
+    maxConcurrency: 2,
+    command: "run",
+    allowUnverifiedAgent: false,
+    rest: [],
+  };
 
   for (let i = 0; i < args.length; i++) {
     // A following token is this flag's value only when it isn't a flag itself,
@@ -470,10 +494,77 @@ export function parseGatewayArgs(args: string[]): GatewayOptions {
       case "--list-auth-methods":
         options.command = "list-auth-methods";
         break;
+      case "--agent":
+        if (value) {
+          options.agentId = value;
+          i++;
+        }
+        break;
+      case "--list-agents":
+        options.command = "list-agents";
+        break;
+      case "--allow-unverified-agent":
+        options.allowUnverifiedAgent = true;
+        break;
+      case "--registry-url":
+        if (value) {
+          options.registryUrl = value;
+          i++;
+        }
+        break;
+      default:
+        // Anything unrecognised belongs to the agent command, which may be
+        // given without a `--` separator.
+        options.rest.push(args[i]);
     }
   }
 
   return options;
+}
+
+/**
+ * Prints every agent the registry publishes, and how each one can be run here.
+ */
+export async function runListAgents(
+  registryUrl?: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+  const registry = await fetchRegistry(registryUrl, fetchImpl);
+  const target = hostPlatformTarget();
+  console.log(
+    `ACP registry v${registry.version} — ${registry.agents.length} agents ` +
+      `(this machine: ${target ?? `${process.platform}/${process.arch}, unsupported`})\n`,
+  );
+  console.log(describeAgents(registry, target));
+  console.log(`\nRun one with: acp-gateway --agent <id>`);
+}
+
+/**
+ * Works out which command actually starts the agent.
+ *
+ * `--agent <id>` resolves through the registry — installing the agent when the
+ * only distribution is a binary — and otherwise the command given after `--`
+ * is used as-is.
+ */
+export async function resolveAgentCommand(
+  options: GatewayOptions,
+  explicitCommand: string[],
+  fetchImpl: typeof fetch = fetch,
+): Promise<{ command: string[]; env?: Record<string, string> }> {
+  if (!options.agentId) return { command: explicitCommand };
+
+  const registry = await fetchRegistry(options.registryUrl, fetchImpl);
+  const spec = await resolveAgentLaunch({
+    id: options.agentId,
+    registry,
+    platformTarget: hostPlatformTarget(),
+    allowUnverified: options.allowUnverifiedAgent,
+    fetchImpl,
+  });
+  console.error(
+    `[registry] Running "${options.agentId}" via ${spec.kind}: ${spec.command} ${spec.args.join(" ")}`,
+  );
+  return { command: [spec.command, ...spec.args], env: spec.env };
 }
 
 /**
@@ -532,10 +623,13 @@ export function printUsage(): void {
   console.log(
     "Usage: acp-gateway [--max-concurrency <number>] [--auth-method <id>] -- <acp-server-command> [args...]",
   );
+  console.log("       acp-gateway --agent <registry-id> [--allow-unverified-agent]");
+  console.log("       acp-gateway --list-agents");
   console.log("       acp-gateway --list-auth-methods -- <acp-server-command> [args...]");
   console.log("       acp-gateway --login [method-id] -- <acp-server-command> [args...]");
   console.log("       acp-gateway --logout -- <acp-server-command> [args...]");
   console.log("Example: acp-gateway --max-concurrency 4 -- gemini --acp");
+  console.log("Example: acp-gateway --agent gemini");
 }
 
 async function main() {
@@ -543,27 +637,46 @@ async function main() {
 
   const args = process.argv.slice(2);
 
-  // Find where the command starts (after -- if provided, or just all args)
+  // Everything after `--` is the agent command. Without a separator the
+  // gateway's own options are still recognised and whatever is left over is
+  // the command, so `acp-gateway --agent gemini` needs no trailing `--`.
   const cmdStartIndex = args.indexOf("--");
-  const acpCmdArgs =
-    cmdStartIndex !== -1 ? args.slice(cmdStartIndex + 1) : args;
+  const gatewayArgs = cmdStartIndex !== -1 ? args.slice(0, cmdStartIndex) : args;
+  const options = parseGatewayArgs(gatewayArgs);
+  const explicitCommand =
+    cmdStartIndex !== -1 ? args.slice(cmdStartIndex + 1) : options.rest;
 
-  if (acpCmdArgs.length === 0) {
-    printUsage();
-    process.exit(1);
+  const { maxConcurrency, command, authMethodId } = options;
+
+  // Listing the registry needs neither a workspace nor an agent.
+  if (command === "list-agents") {
+    await runListAgents(options.registryUrl);
+    process.exit(0);
   }
 
   // 1. Load MCP Config
   const configs = loadMcpConfig();
   const agentrqConfig = pickAgentrqServer(configs);
 
-  const gatewayArgs = cmdStartIndex !== -1 ? args.slice(0, cmdStartIndex) : [];
-  const { maxConcurrency, command, authMethodId } = parseGatewayArgs(gatewayArgs);
+  // 2. Work out what actually starts the agent — a registry id, or the command
+  // the user gave.
+  const resolved = await resolveAgentCommand(options, explicitCommand);
+  const acpCmdArgs = resolved.command;
+  if (acpCmdArgs.length === 0) {
+    printUsage();
+    process.exit(1);
+  }
+  if (resolved.env) {
+    // The registry entry's env is part of how that agent must be launched, so
+    // it travels with the command into every session spawned from it.
+    agentrqConfig.env = { ...agentrqConfig.env, ...resolved.env };
+  }
+
   authConfig.methodId = authMethodId;
 
   const taskQueue = new TaskQueue(maxConcurrency);
 
-  // 2. Initialize MCP Bridge
+  // 3. Initialize MCP Bridge
   const mcpBridge = new MCPBridge(agentrqConfig);
 
   // Auth commands talk to the agent and exit; they never start bridging tasks.

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,8 @@
 
 import { spawn } from "node:child_process";
 import { Writable, Readable } from "node:stream";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import * as path from "node:path";
 import * as acp from "@agentclientprotocol/sdk";
 const pkg = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
@@ -573,6 +574,46 @@ export async function resolveAgentCommand(
 }
 
 /**
+ * Whether a command can actually be run.
+ *
+ * A path is checked directly; a bare name is looked for along PATH, honouring
+ * PATHEXT on Windows where an executable is rarely named without a suffix.
+ */
+export function isRunnable(
+  command: string,
+  env: NodeJS.ProcessEnv = process.env,
+  platform: string = process.platform,
+): boolean {
+  if (command.includes("/") || (platform === "win32" && command.includes("\\"))) {
+    return existsSync(command);
+  }
+  const extensions =
+    platform === "win32" ? (env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";") : [""];
+  const separator = platform === "win32" ? ";" : ":";
+  return (env.PATH ?? "")
+    .split(separator)
+    .filter(Boolean)
+    .some((dir) => extensions.some((ext) => existsSync(path.join(dir, command + ext))));
+}
+
+/**
+ * Refuses to start with an agent that cannot be run.
+ *
+ * The agent is not spawned until the first task arrives, so without this a
+ * mistyped command — or a registry id passed as if it were one — starts a
+ * gateway that looks healthy and only fails much later, out of sight.
+ */
+export function assertAgentRunnable(command: string, usedRegistryId: boolean): void {
+  if (isRunnable(command)) return;
+
+  const hint = usedRegistryId
+    ? `The registry says to run it as "${command}", which is not installed.`
+    : `If "${command}" is an ACP registry agent id, run it with --agent ${command} ` +
+      `(--list-agents shows what is published).`;
+  throw new Error(`Agent command "${command}" was not found. ${hint}`);
+}
+
+/**
  * Runs a one-shot auth command against the agent and shuts it down again.
  *
  * These commands exist so a login can be done deliberately — before any task
@@ -723,8 +764,21 @@ async function main() {
 
   // 2. Work out what actually starts the agent — a registry id, or the command
   // the user gave.
-  const resolved = await resolveAgentCommand(options, explicitCommand);
+  // These failures are all things the user can act on — an unknown registry
+  // id, no build for this platform, an unverifiable download, a mistyped
+  // command — so they get a sentence rather than a stack trace.
+  const fail = (err: unknown): never => {
+    console.error(`[acp-gateway] ${err instanceof Error ? err.message : err}`);
+    return process.exit(1);
+  };
+
+  const resolved = await resolveAgentCommand(options, explicitCommand).catch(fail);
   const acpCmdArgs = resolved.command;
+  try {
+    assertAgentRunnable(acpCmdArgs[0], Boolean(options.agentId));
+  } catch (err) {
+    fail(err);
+  }
   if (resolved.env) {
     // The registry entry's env is part of how that agent must be launched, so
     // it travels with the command into every session spawned from it.

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,0 +1,205 @@
+/**
+ * registry.ts
+ *
+ * Resolves ACP agents from the public registry, so an agent can be named by id
+ * instead of being installed and wired up by hand.
+ *
+ * The registry publishes one index of every agent it lists, each entry saying
+ * how the agent is distributed: an npm package run through `npx`, a PyPI
+ * package run through `uvx`, or a platform-specific binary to download.
+ *
+ * See https://github.com/agentclientprotocol/registry
+ */
+
+/** The registry index, as published by the ACP project. */
+export const DEFAULT_REGISTRY_URL =
+  "https://cdn.agentclientprotocol.com/registry/v1/latest/registry.json";
+
+/** Platform identifiers the registry uses for binary distributions. */
+export type PlatformTarget =
+  | "darwin-aarch64"
+  | "darwin-x86_64"
+  | "linux-aarch64"
+  | "linux-x86_64"
+  | "windows-aarch64"
+  | "windows-x86_64";
+
+export interface BinaryTarget {
+  archive: string;
+  /** SHA-256 of the archive. Optional in the registry — many entries omit it. */
+  sha256?: string;
+  /** Path to the executable, relative to the extracted archive. */
+  cmd: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+export interface PackageDistribution {
+  /** Package name, which may pin a version (e.g. `@google/gemini-cli@0.58.0`). */
+  package: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+export interface AgentDistribution {
+  binary?: Partial<Record<PlatformTarget, BinaryTarget>>;
+  npx?: PackageDistribution;
+  uvx?: PackageDistribution;
+}
+
+export interface RegistryAgent {
+  id: string;
+  name: string;
+  version: string;
+  description: string;
+  repository?: string;
+  website?: string;
+  authors?: string[];
+  license?: string;
+  distribution: AgentDistribution;
+}
+
+export interface Registry {
+  version: string;
+  agents: RegistryAgent[];
+}
+
+/** How an agent named in the registry is actually launched. */
+export interface LaunchSpec {
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+  /** Which distribution this came from, for logging. */
+  kind: "npx" | "uvx" | "binary";
+}
+
+/** Node's platform/arch names mapped onto the registry's identifiers. */
+const PLATFORMS: Record<string, string> = { darwin: "darwin", linux: "linux", win32: "windows" };
+const ARCHITECTURES: Record<string, string> = { arm64: "aarch64", x64: "x86_64" };
+
+/**
+ * The registry platform identifier for the machine we are running on, or
+ * undefined where the registry publishes nothing for it.
+ */
+export function hostPlatformTarget(
+  platform: string = process.platform,
+  arch: string = process.arch,
+): PlatformTarget | undefined {
+  const os = PLATFORMS[platform];
+  const cpu = ARCHITECTURES[arch];
+  if (!os || !cpu) return undefined;
+  return `${os}-${cpu}` as PlatformTarget;
+}
+
+/** Rejects anything that is not a registry index, so a bad URL fails loudly. */
+function assertRegistry(value: unknown, url: string): asserts value is Registry {
+  const agents = (value as { agents?: unknown } | null)?.agents;
+  if (!Array.isArray(agents)) {
+    throw new Error(`${url} did not return an ACP registry index.`);
+  }
+}
+
+/**
+ * Downloads the registry index.
+ *
+ * `fetchImpl` and `url` are injectable so a pinned or local registry can be
+ * used instead of the published one.
+ */
+export async function fetchRegistry(
+  url: string = DEFAULT_REGISTRY_URL,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Registry> {
+  const response = await fetchImpl(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch the ACP registry from ${url}: ${response.status} ${response.statusText}`);
+  }
+  const body = await response.json();
+  assertRegistry(body, url);
+  return body;
+}
+
+/** Finds one agent by its registry id. */
+export function findAgent(registry: Registry, id: string): RegistryAgent | undefined {
+  return registry.agents.find((agent) => agent.id === id);
+}
+
+/**
+ * Renders the registry as a table for the terminal.
+ *
+ * `target` is passed in rather than defaulted, so that "this machine has no
+ * published build" stays distinguishable from "caller did not say".
+ */
+export function describeAgents(
+  registry: Registry,
+  target: PlatformTarget | undefined,
+): string {
+  const rows = registry.agents.map((agent) => {
+    const kinds = availableKinds(agent, target);
+    const support = kinds.length ? kinds.join(", ") : "unavailable on this platform";
+    return `  ${agent.id.padEnd(22)} ${agent.name} — ${support}`;
+  });
+  return rows.join("\n");
+}
+
+/** Which distributions of this agent can actually run on this machine. */
+export function availableKinds(
+  agent: RegistryAgent,
+  target: PlatformTarget | undefined,
+): LaunchSpec["kind"][] {
+  const kinds: LaunchSpec["kind"][] = [];
+  if (agent.distribution.npx) kinds.push("npx");
+  if (agent.distribution.uvx) kinds.push("uvx");
+  if (target && agent.distribution.binary?.[target]) kinds.push("binary");
+  return kinds;
+}
+
+/**
+ * Picks the binary build for this machine.
+ *
+ * Throws rather than falling back to another platform's build: running the
+ * wrong architecture would fail in a much more confusing way.
+ */
+export function selectBinaryTarget(
+  agent: RegistryAgent,
+  target: PlatformTarget | undefined,
+): BinaryTarget {
+  const binary = agent.distribution.binary;
+  if (!binary) {
+    throw new Error(`Agent "${agent.id}" publishes no binary distribution.`);
+  }
+  if (!target) {
+    throw new Error(
+      `The ACP registry publishes no binaries for ${process.platform}/${process.arch}.`,
+    );
+  }
+  const selected = binary[target];
+  if (!selected) {
+    throw new Error(
+      `Agent "${agent.id}" publishes no binary for ${target} ` +
+        `(available: ${Object.keys(binary).join(", ")}).`,
+    );
+  }
+  return selected;
+}
+
+/**
+ * Turns an npm or PyPI distribution into the command that runs it.
+ *
+ * On Windows npm installs `npx` as `npx.cmd`; spawning a bare "npx" there
+ * looks only for `npx.exe` and fails, so the runner is named explicitly.
+ */
+export function packageLaunchSpec(
+  kind: "npx" | "uvx",
+  distribution: PackageDistribution,
+  platform: string = process.platform,
+): LaunchSpec {
+  // `npx -y` skips the install prompt, which would otherwise block a gateway
+  // that nobody is watching.
+  const args = kind === "npx" ? ["-y", distribution.package] : [distribution.package];
+  return {
+    command: kind === "npx" && platform === "win32" ? "npx.cmd" : kind,
+    args: [...args, ...(distribution.args ?? [])],
+    env: distribution.env,
+    kind,
+  };
+}


### PR DESCRIPTION
## What changed

Agents can now be run by name from the public ACP registry, so you no longer have to install one yourself and wire up its command. One option lists everything the registry publishes and how each entry can run on your machine; another runs one of them. Where an agent is distributed as a downloadable binary, it is fetched, checked against the registry's published checksum, unpacked and cached — and refused outright when there is no checksum to check it against, unless you explicitly say otherwise.

The command line also explains itself now: a help menu describes every option, grouped by what it is for, and appears both on request and whenever the gateway is started with nothing to do.

## Why changed

Getting an agent running meant installing it by hand and knowing the exact command and flags it wants. The registry already describes all of that for every agent it lists, and it is the same list that guarantees the agents support the sign-in flow added in the previous change — so the two together take someone from nothing to a working, authenticated agent. None of which helps if the options are undiscoverable, hence the help.

## Test coverage report

- **New lines: 100%** — both new modules are at 100% statements, branches and functions. Every new line outside the `main()` entry point is covered; the 17 uncovered new lines are command-line wiring inside `main()`, which the suite has never invoked.
- **Total coverage impact:** statements 86.11% → 87.68%, branches 87.91% → 89.33%, lines 86.24% → 87.63%, functions 81.98% → 85.81%.
- Test count: 170 → 240, all passing. `npm run typecheck` and `npm run build` clean.
- One test asserts that the set of options documented in the help and the set the parser accepts are identical, so the two cannot drift apart.

## Other reports

**Cross-platform:** all six platforms the registry publishes for are handled — macOS, Linux and Windows on x86_64 and arm64. Three platform differences are handled explicitly: archives are unpacked with the system `tar`, falling back to `unzip` for zips on Linux where `tar` cannot read them; `npx` is spawned as `npx.cmd` on Windows, where a bare `npx` cannot be spawned at all; and the download cache follows each platform's own convention (`%LOCALAPPDATA%` on Windows, `XDG_CACHE_HOME` elsewhere).

**Security posture**, since this feature downloads and executes third-party code:
- A binary with no published checksum is refused; installing one takes an explicit opt-in.
- A download whose checksum does not match is refused and never reaches the cache.
- A command path that points outside its own install directory is refused.
- Package distributions are preferred over binaries wherever an agent offers both, so nothing is downloaded when npm or PyPI can serve and verify it.
- A failed unpack leaves nothing cached — installs are staged and only moved into place once they succeed.

**Verified end to end** against a local registry serving a real archive: resolve → download → checksum → unpack → cache → launch → ACP handshake, including cache reuse on the second run, a mismatched checksum rejected, a missing checksum rejected and then installed under the opt-in. Also verified against the live registry (39 agents listed, correct platform detection), and that the help appears correctly with no arguments, outside a workspace, and exits non-zero there.

TaskID: 0i4Qs2kHhJZ

🤖 Generated with [AgentRQ](https://agentrq.com)