### PR TITLE
feat: show what an agent says it supports

### DIFF
--- a/src/__tests__/agentInfo.test.ts
+++ b/src/__tests__/agentInfo.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { describeAgentInfo } from "../agentInfo.js";
+
+/** A minimal initialize response, with only what a test cares about set. */
+function initResult(overrides: Record<string, unknown> = {}): any {
+  return { protocolVersion: 1, ...overrides };
+}
+
+describe("describeAgentInfo", () => {
+  it("should name the agent as it named itself", () => {
+    const text = describeAgentInfo(
+      initResult({
+        agentInfo: { name: "antigravity-acp", title: "Google Antigravity", version: "1.2.3" },
+      }),
+      "some-binary --acp",
+    );
+
+    expect(text.split("\n")[0]).toBe("antigravity-acp — Google Antigravity 1.2.3");
+  });
+
+  it("should not repeat a title that only restates the name", () => {
+    const text = describeAgentInfo(
+      initResult({ agentInfo: { name: "gemini", title: "gemini" } }),
+      "gemini --acp",
+    );
+
+    expect(text.split("\n")[0]).toBe("gemini");
+  });
+
+  it("should fall back to how the agent was launched when it names no name", () => {
+    expect(describeAgentInfo(initResult(), "gemini --acp").split("\n")[0]).toBe("gemini --acp");
+    expect(
+      describeAgentInfo(initResult({ agentInfo: { version: "1.0" } }), "gemini --acp").split(
+        "\n",
+      )[0],
+    ).toBe("gemini --acp");
+  });
+
+  it("should report the protocol version the agent negotiated", () => {
+    expect(describeAgentInfo(initResult({ protocolVersion: 2 }), "x")).toContain(
+      "ACP protocol version 2",
+    );
+  });
+
+  it("should read a capability supplied as {} as supported", () => {
+    const text = describeAgentInfo(
+      initResult({
+        agentCapabilities: {
+          loadSession: true,
+          sessionCapabilities: { list: {}, resume: {} },
+        },
+      }),
+      "x",
+    );
+
+    expect(text).toContain("session/load    yes");
+    expect(text).toContain("session/list    yes");
+    expect(text).toContain("session/resume  yes");
+    // Absent, null and false all mean the agent does not support it.
+    expect(text).toContain("session/close   no");
+    expect(text).toContain("session/fork    no");
+  });
+
+  it("should treat an explicitly false or null capability as unsupported", () => {
+    const text = describeAgentInfo(
+      initResult({
+        agentCapabilities: {
+          loadSession: false,
+          sessionCapabilities: { resume: null },
+          promptCapabilities: { image: false, audio: true, embeddedContext: true },
+        },
+      }),
+      "x",
+    );
+
+    expect(text).toContain("session/load    no");
+    expect(text).toContain("session/resume  no");
+    expect(text).toContain("image             no");
+    expect(text).toContain("audio             yes");
+    expect(text).toContain("embedded context  yes");
+  });
+
+  it("should report every MCP transport, including the unstable acp one", () => {
+    const text = describeAgentInfo(
+      initResult({ agentCapabilities: { mcpCapabilities: { http: true, sse: true } } }),
+      "x",
+    );
+
+    expect(text).toContain("http  yes");
+    expect(text).toContain("sse   yes");
+    expect(text).toContain("acp   no");
+  });
+
+  it("should list the login methods alongside logout support", () => {
+    const text = describeAgentInfo(
+      initResult({
+        agentCapabilities: { auth: { logout: {} } },
+        authMethods: [{ id: "oauth-personal", name: "Log in with Google" }],
+      }),
+      "x",
+    );
+
+    expect(text).toContain("logout  yes");
+    expect(text).toContain("Log in with Google (oauth-personal)");
+  });
+
+  it("should say plainly when an agent needs no login at all", () => {
+    const text = describeAgentInfo(initResult(), "x");
+
+    expect(text).toContain("logout  no");
+    expect(text).toContain("no authentication methods");
+  });
+
+  it("should describe an agent that reports no capabilities at all", () => {
+    const text = describeAgentInfo(initResult({ agentCapabilities: null }), "x");
+
+    expect(text).toContain("session/load    no");
+    expect(text).toContain("image             no");
+    expect(text).toContain("http  no");
+  });
+});

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -22,7 +22,7 @@ import {
   runListAgents,
   pickHumanApprovalMode,
   enforceHumanApprovalMode,
-  runAuthCommand,
+  runAgentCommand,
 } from "../index.js";
 import { AUTH_REQUIRED_CODE } from "../auth.js";
 import type { McpServerConfig } from "../config.js";
@@ -790,7 +790,7 @@ describe("index", () => {
     });
   });
 
-  describe("runAuthCommand", () => {
+  describe("runAgentCommand", () => {
     const agentrqConfig: any = { env: {} };
     let logSpy: any;
     let errorSpy: any;
@@ -818,7 +818,7 @@ describe("index", () => {
         agentCapabilities: { auth: { logout: {} } },
       });
 
-      await runAuthCommand("list-auth-methods", ["gemini", "--acp"], agentrqConfig, {} as any);
+      await runAgentCommand("list-auth-methods", ["gemini", "--acp"], agentrqConfig, {} as any);
 
       const printed = logSpy.mock.calls.flat().join("\n");
       expect(printed).toContain("Agent login (agent-login)");
@@ -826,10 +826,31 @@ describe("index", () => {
       expect(spawnedAgents[0].kill).toHaveBeenCalled();
     });
 
+    it("should print what the agent says it supports", async () => {
+      mockConnection({}, {
+        protocolVersion: 1,
+        agentCapabilities: {
+          loadSession: true,
+          sessionCapabilities: { resume: {} },
+          mcpCapabilities: { http: true },
+        },
+      });
+
+      await runAgentCommand("agent-info", ["gemini", "--acp"], agentrqConfig, {} as any);
+
+      const printed = String(logSpy.mock.calls.at(-1)[0]);
+      expect(printed).toContain("gemini --acp");
+      expect(printed).toContain("ACP protocol version 1");
+      expect(printed).toContain("session/resume  yes");
+      expect(printed).toContain("session/close   no");
+      expect(printed).toContain("http  yes");
+      expect(spawnedAgents[0].kill).toHaveBeenCalled();
+    });
+
     it("should report agents that advertise no login", async () => {
       mockConnection({});
 
-      await runAuthCommand("list-auth-methods", ["gemini", "--acp"], agentrqConfig, {} as any);
+      await runAgentCommand("list-auth-methods", ["gemini", "--acp"], agentrqConfig, {} as any);
 
       expect(logSpy.mock.calls.flat().join("\n")).toContain("no authentication methods");
     });
@@ -839,7 +860,7 @@ describe("index", () => {
         agentCapabilities: { auth: { logout: {} } },
       });
 
-      await runAuthCommand("logout", ["gemini", "--acp"], agentrqConfig, {} as any);
+      await runAgentCommand("logout", ["gemini", "--acp"], agentrqConfig, {} as any);
 
       expect(connection.logout).toHaveBeenCalledWith({});
     });
@@ -852,7 +873,7 @@ describe("index", () => {
         ],
       });
 
-      await runAuthCommand("login", ["gemini", "--acp"], agentrqConfig, {} as any, "oauth");
+      await runAgentCommand("login", ["gemini", "--acp"], agentrqConfig, {} as any, "oauth");
 
       expect(connection.authenticate).toHaveBeenCalledWith({ methodId: "oauth" });
     });
@@ -863,7 +884,7 @@ describe("index", () => {
       });
 
       await expect(
-        runAuthCommand("login", ["gemini", "--acp"], agentrqConfig, {} as any, "missing"),
+        runAgentCommand("login", ["gemini", "--acp"], agentrqConfig, {} as any, "missing"),
       ).rejects.toThrow(/Unknown authentication method/);
       expect(spawnedAgents[0].kill).toHaveBeenCalled();
     });
@@ -880,6 +901,7 @@ describe("index", () => {
         new Set([
           "--agent",
           "--list-agents",
+          "--agent-info",
           "--allow-unverified-agent",
           "--registry-url",
           "--list-auth-methods",

--- a/src/agentInfo.ts
+++ b/src/agentInfo.ts
@@ -1,0 +1,89 @@
+/**
+ * agentInfo.ts
+ *
+ * Renders what an agent said about itself during `initialize`.
+ *
+ * An agent's capabilities are only knowable from a live handshake — nothing in
+ * the registry lists them — so the answer to "can this agent resume a session?"
+ * or "will it accept an HTTP MCP server?" is otherwise a guess.
+ */
+
+import * as acp from "@agentclientprotocol/sdk";
+import { describeAuthMethods } from "./auth.js";
+
+/** ACP marks an optional capability as supported by supplying `{}` for it. */
+function supported(value: unknown): boolean {
+  return value !== undefined && value !== null && value !== false;
+}
+
+function yesNo(value: unknown): string {
+  return supported(value) ? "yes" : "no";
+}
+
+function section(title: string, rows: Array<[string, string]>): string {
+  const width = Math.max(...rows.map(([label]) => label.length));
+  const body = rows.map(([label, value]) => `  ${label.padEnd(width)}  ${value}`);
+  return [title, ...body].join("\n");
+}
+
+/** The agent's own name for itself, falling back to how it was launched. */
+function heading(
+  initResult: acp.InitializeResponse,
+  launchedAs: string,
+): string {
+  const info = (initResult as { agentInfo?: { name?: string; title?: string; version?: string } })
+    .agentInfo;
+  if (!info?.name) return launchedAs;
+
+  const title = info.title && info.title !== info.name ? ` — ${info.title}` : "";
+  const version = info.version ? ` ${info.version}` : "";
+  return `${info.name}${title}${version}`;
+}
+
+/**
+ * Describes an agent's capabilities as the agent itself reported them.
+ *
+ * `launchedAs` is only used when the agent supplies no `agentInfo`, so that the
+ * output still says which agent is being described.
+ */
+export function describeAgentInfo(
+  initResult: acp.InitializeResponse,
+  launchedAs: string,
+): string {
+  const caps = (initResult.agentCapabilities ?? {}) as acp.AgentCapabilities & {
+    sessionCapabilities?: Record<string, unknown>;
+  };
+  const sessions = caps.sessionCapabilities ?? {};
+  const prompt = caps.promptCapabilities ?? {};
+  const mcp = caps.mcpCapabilities ?? {};
+
+  const blocks = [
+    `${heading(initResult, launchedAs)}\nACP protocol version ${initResult.protocolVersion}`,
+
+    section("SESSIONS", [
+      ["session/load", yesNo(caps.loadSession)],
+      ["session/list", yesNo(sessions.list)],
+      ["session/resume", yesNo(sessions.resume)],
+      ["session/close", yesNo(sessions.close)],
+      ["session/delete", yesNo(sessions.delete)],
+      ["session/fork", yesNo(sessions.fork)],
+    ]),
+
+    section("PROMPT CONTENT", [
+      ["image", yesNo(prompt.image)],
+      ["audio", yesNo(prompt.audio)],
+      ["embedded context", yesNo(prompt.embeddedContext)],
+    ]),
+
+    section("MCP TRANSPORTS", [
+      ["http", yesNo(mcp.http)],
+      ["sse", yesNo(mcp.sse)],
+      ["acp", yesNo((mcp as { acp?: unknown }).acp)],
+    ]),
+
+    section("AUTHENTICATION", [["logout", yesNo(caps.auth?.logout)]]) +
+      `\n\n  Login methods:\n${describeAuthMethods(initResult.authMethods)}`,
+  ];
+
+  return blocks.join("\n\n");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ import {
   type LoginOptions,
 } from "./auth.js";
 import { resolveAgentLaunch } from "./agentInstall.js";
+import { describeAgentInfo } from "./agentInfo.js";
 import {
   describeAgents,
   fetchRegistry,
@@ -433,6 +434,7 @@ export type GatewayCommand =
   | "logout"
   | "list-auth-methods"
   | "list-agents"
+  | "agent-info"
   | "help";
 
 export interface GatewayOptions {
@@ -504,6 +506,9 @@ export function parseGatewayArgs(args: string[]): GatewayOptions {
         break;
       case "--list-agents":
         options.command = "list-agents";
+        break;
+      case "--agent-info":
+        options.command = "agent-info";
         break;
       case "--allow-unverified-agent":
         options.allowUnverifiedAgent = true;
@@ -614,12 +619,13 @@ export function assertAgentRunnable(command: string, usedRegistryId: boolean): v
 }
 
 /**
- * Runs a one-shot auth command against the agent and shuts it down again.
+ * Runs a one-shot command against the agent and shuts it down again.
  *
- * These commands exist so a login can be done deliberately — before any task
- * arrives — rather than only when a session is refused.
+ * These commands exist so a login — or a look at what the agent supports — can
+ * be done deliberately, before any task arrives, rather than only when a
+ * session is refused.
  */
-export async function runAuthCommand(
+export async function runAgentCommand(
   command: Exclude<GatewayCommand, "run">,
   acpCmdArgs: string[],
   agentrqConfig: McpServerConfig,
@@ -637,6 +643,11 @@ export async function runAuthCommand(
   try {
     const connection = agent.connection as unknown as AuthConnection;
     const { authMethods, agentCapabilities } = agent.initResult;
+
+    if (command === "agent-info") {
+      console.log(describeAgentInfo(agent.initResult, acpCmdArgs.join(" ")));
+      return;
+    }
 
     if (command === "list-auth-methods") {
       console.log(
@@ -687,6 +698,9 @@ AGENT
                               if needed, instead of a command you supply.
   --list-agents               List every agent in the registry, and how each one
                               can run on this machine. Exits.
+  --agent-info                What the agent says it supports — session
+                              lifecycle, prompt content, MCP transports and
+                              logins. Only a live handshake can tell you. Exits.
   --allow-unverified-agent    Install a registry binary that publishes no
                               checksum. Off by default: without a checksum there
                               is no way to tell what was downloaded.
@@ -712,6 +726,7 @@ EXAMPLES
   acp-gateway --agent gemini                     Run Gemini from the registry
   acp-gateway -- gemini --acp                    Run an agent you installed
   acp-gateway --list-agents                      See what the registry offers
+  acp-gateway --agent-info --agent gemini        See what that agent supports
   acp-gateway --login -- gemini --acp            Log in before running anything
   acp-gateway --max-concurrency 4 -- gemini --acp
 
@@ -798,7 +813,7 @@ async function main() {
   // actually needs to reach agentrq.
   if (command !== "run") {
     try {
-      await runAuthCommand(command, acpCmdArgs, agentrqConfig, mcpBridge, authMethodId);
+      await runAgentCommand(command, acpCmdArgs, agentrqConfig, mcpBridge, authMethodId);
     } finally {
       await mcpBridge.close();
     }


### PR DESCRIPTION
**What changed**

A new one-shot command asks the agent what it supports — session lifecycle, prompt content types, MCP transports and logins — prints it and exits.

**Why changed**

Those capabilities only exist in a live handshake response; nothing in the registry publishes them. Whether features like session resume or HTTP MCP servers are worth building against a given agent was previously a guess, and there was no way to check in the field either.

**Test coverage report**

- New lines introduced: 100% (the new formatter is fully covered, plus a command-level test through the existing agent-command harness)
- Total coverage impact: statements 87.21% → 87.33%, lines 87.09% → 87.18%; 247 → 258 tests, all passing
- Verified end to end against a real ACP agent (`antigravity-acp` from the registry), which reports `loadSession`/`list`/`resume` but not `close`

TaskID: 0i4isY22vz7

Generated with [AgentRQ](https://agentrq.com)