### PR TITLE
chore: hand agents MCP servers they can use, and report cut-short turns

### DIFF
--- a/src/__tests__/acpClient.test.ts
+++ b/src/__tests__/acpClient.test.ts
@@ -1107,6 +1107,57 @@ describe("AgentRQACPClient", () => {
     });
   });
 
+  describe("reportStopReason", () => {
+    function clientForTask(taskId: string | undefined) {
+      return new AgentRQACPClient(mcpBridge as unknown as MCPBridge, () => taskId);
+    }
+
+    it("should say nothing when the agent simply finished", async () => {
+      await clientForTask("task-1").reportStopReason("sess-1", "end_turn");
+
+      expect(mcpBridge.callTool).not.toHaveBeenCalled();
+    });
+
+    it("should tell the workspace when a turn was refused or cut short", async () => {
+      const client = clientForTask("task-1");
+
+      await client.reportStopReason("sess-1", "refusal");
+      await client.reportStopReason("sess-1", "max_tokens");
+      await client.reportStopReason("sess-1", "max_turn_requests");
+      await client.reportStopReason("sess-1", "cancelled");
+
+      const texts = mcpBridge.callTool.mock.calls.map((c: any[]) => c[1].text);
+      expect(mcpBridge.callTool.mock.calls.every((c: any[]) => c[0] === "reply")).toBe(true);
+      expect(texts[0]).toContain("refused");
+      expect(texts[1]).toContain("ran out of output tokens");
+      expect(texts[2]).toContain("model requests");
+      expect(texts[3]).toContain("cancelled");
+    });
+
+    it("should still report a stop reason it does not recognise", async () => {
+      await clientForTask("task-1").reportStopReason("sess-1", "something_new");
+
+      expect(mcpBridge.callTool).toHaveBeenCalledWith("reply", {
+        chatId: "task-1",
+        text: expect.stringContaining("something_new"),
+      });
+    });
+
+    it("should skip a session with no task behind it", async () => {
+      await clientForTask(undefined).reportStopReason("sess-1", "refusal");
+
+      expect(mcpBridge.callTool).not.toHaveBeenCalled();
+    });
+
+    it("should survive a workspace that cannot be reached", async () => {
+      mcpBridge.callTool.mockRejectedValue(new Error("offline"));
+
+      await expect(
+        clientForTask("task-1").reportStopReason("sess-1", "refusal"),
+      ).resolves.toBeUndefined();
+    });
+  });
+
   describe("file operations", () => {
     it("should read text files", async () => {
       vi.mocked(path.resolve).mockReturnValue("/mock/path/file.txt");

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -36,6 +36,61 @@ describe("config", () => {
       });
     });
 
+    it("should pass an sse server through as its own transport", () => {
+      vi.mocked(resolve).mockImplementation((...args: string[]) => args.join("/"));
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+        mcpServers: { "events": { type: "sse", url: "http://example.com/sse" } }
+      }));
+
+      expect(loadMcpConfig("/dummy")[0].type).toBe("sse");
+    });
+
+    it("should refuse a transport it cannot hand to an agent", () => {
+      vi.mocked(resolve).mockImplementation((...args: string[]) => args.join("/"));
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+        mcpServers: { "odd": { type: "websocket", url: "ws://example.com" } }
+      }));
+
+      // Silently treating this as stdio produced a server with no command and
+      // an agent that could not say what was wrong.
+      expect(() => loadMcpConfig("/dummy")).toThrow(/transport "websocket"/);
+      expect(() => loadMcpConfig("/dummy")).toThrow(/http, sse, stdio/);
+    });
+
+    it("should refuse an entry missing the field its transport needs", () => {
+      vi.mocked(resolve).mockImplementation((...args: string[]) => args.join("/"));
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+        mcpServers: { "agentrq": { type: "http" } }
+      }));
+      expect(() => loadMcpConfig("/dummy")).toThrow(/is http but has no url/);
+
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+        mcpServers: { "local": { type: "stdio", args: ["x"] } }
+      }));
+      expect(() => loadMcpConfig("/dummy")).toThrow(/is stdio but has no command/);
+    });
+
+    it("should report a mistake in the file it found rather than looking further up", () => {
+      vi.mocked(resolve).mockImplementation((...args: string[]) => args.join("/"));
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+        mcpServers: { "odd": { type: "websocket", url: "ws://example.com" } }
+      }));
+
+      expect(() => loadMcpConfig("/dummy")).not.toThrow(/Could not find/);
+    });
+
+    it("should keep looking when a candidate file cannot be read or parsed", () => {
+      vi.mocked(resolve).mockImplementation((...args: string[]) => args.join("/"));
+      vi.mocked(readFileSync)
+        .mockImplementationOnce(() => { throw new Error("ENOENT"); })
+        .mockReturnValueOnce("{ not json")
+        .mockReturnValue(JSON.stringify({
+          mcpServers: { "agentrq": { type: "http", url: "http://localhost:8080" } }
+        }) as any);
+
+      expect(loadMcpConfig("/dummy")[0].name).toBe("agentrq");
+    });
+
     it("should handle missing mcpServers in JSON", () => {
       vi.mocked(resolve).mockImplementation((...args: string[]) => args.join("/"));
       vi.mocked(readFileSync).mockReturnValue(JSON.stringify({}));

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -96,6 +96,53 @@ describe("index", () => {
       }]);
     });
 
+    it("should map an sse server as its own transport", () => {
+      const configs: McpServerConfig[] = [{
+        type: "sse",
+        name: "events",
+        url: "http://localhost:8000/sse",
+      }];
+
+      expect(mapMcpServers(configs, { mcpCapabilities: { sse: true } } as any)).toEqual([{
+        type: "sse",
+        name: "events",
+        url: "http://localhost:8000/sse",
+        headers: [],
+      }]);
+    });
+
+    it("should leave out a transport the agent says it does not support", () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const configs: McpServerConfig[] = [
+        { type: "http", name: "remote", url: "http://localhost:8000" },
+        { type: "stdio", name: "local", command: "npx" },
+      ];
+
+      // An agent may refuse the whole session/new rather than skip one entry.
+      const result = mapMcpServers(configs, {
+        mcpCapabilities: { http: false, sse: false },
+      } as any);
+
+      expect(result.map((s: any) => s.name)).toEqual(["local"]);
+      expect(errorSpy.mock.calls.flat().join("\n")).toContain(
+        'Not passing MCP server "remote"',
+      );
+      errorSpy.mockRestore();
+    });
+
+    it("should still hand over a transport the agent never mentions", () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const configs: McpServerConfig[] = [
+        { type: "http", name: "remote", url: "http://localhost:8000" },
+      ];
+
+      // A terse agent is likelier than one that genuinely cannot reach HTTP,
+      // and dropping this would take the workspace's own server away from it.
+      expect(mapMcpServers(configs, {} as any).map((s: any) => s.name)).toEqual(["remote"]);
+      expect(mapMcpServers(configs).map((s: any) => s.name)).toEqual(["remote"]);
+      errorSpy.mockRestore();
+    });
+
     it("should correctly map stdio servers", () => {
       const configs: McpServerConfig[] = [{
         type: "stdio",

--- a/src/acpClient.ts
+++ b/src/acpClient.ts
@@ -13,6 +13,20 @@ import * as path from "node:path";
 /** Identifies a tool call routed through an agentrq MCP server. */
 const AGENTRQ_TOOL_PATTERN = /agentrq-[a-zA-Z0-9]{11}/;
 
+/**
+ * What a turn ending in anything but `end_turn` means, in the human's terms.
+ *
+ * Without this the workspace sees the agent's partial answer and nothing else,
+ * so a refused or truncated turn is indistinguishable from a finished one.
+ */
+const STOP_REASON_NOTES: Record<string, string> = {
+  refusal: "⚠️ The agent refused to continue this turn.",
+  max_tokens: "⚠️ The agent stopped mid-turn: it ran out of output tokens.",
+  max_turn_requests:
+    "⚠️ The agent stopped mid-turn: it reached its limit on model requests for a single turn.",
+  cancelled: "⚠️ The turn was cancelled before the agent finished.",
+};
+
 export class AgentRQACPClient implements acp.Client {
   private replyBuffers = new Map<string, string>();
   // chatId → text sent by the agent via the reply MCP tool (for dedup in flushReply)
@@ -51,6 +65,32 @@ export class AgentRQACPClient implements acp.Client {
       console.error(`[acp] Forwarded agent reply to task ${taskId}`);
     } catch (err) {
       console.error(`[acp] Failed to forward reply to task ${taskId}:`, err);
+    }
+  }
+
+  /**
+   * Tells the workspace when a turn ended for any reason other than the agent
+   * finishing what it was asked. Call after flushReply, so the note follows
+   * whatever the agent did manage to say.
+   */
+  async reportStopReason(sessionId: string, stopReason: string): Promise<void> {
+    if (stopReason === "end_turn") return;
+
+    const taskId = this.getTaskIdForSession(sessionId);
+    if (!taskId) {
+      console.error(`[acp] No task ID for session ${sessionId}, not reporting "${stopReason}"`);
+      return;
+    }
+
+    const text =
+      STOP_REASON_NOTES[stopReason] ??
+      `⚠️ The agent stopped for a reason this gateway does not recognise: ${stopReason}.`;
+
+    try {
+      await this.mcpBridge.callTool("reply", { chatId: taskId, text });
+      console.error(`[acp] Reported stop reason "${stopReason}" to task ${taskId}`);
+    } catch (err) {
+      console.error(`[acp] Failed to report stop reason to task ${taskId}:`, err);
     }
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,9 +8,14 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
+/** The MCP transports ACP defines that this gateway knows how to hand over. */
+export const MCP_TRANSPORTS = ["http", "sse", "stdio"] as const;
+
+export type McpTransport = (typeof MCP_TRANSPORTS)[number];
+
 export interface McpServerConfig {
   name: string;
-  type: "http" | "stdio";
+  type: McpTransport;
   url?: string;
   command?: string;
   args?: string[];
@@ -22,7 +27,7 @@ interface McpJson {
   mcpServers: Record<
     string,
     {
-      type?: "http" | "stdio";
+      type?: string;
       url?: string;
       command?: string;
       args?: string[];
@@ -45,32 +50,73 @@ export function loadMcpConfig(startDir: string = process.cwd()): McpServerConfig
   ];
 
   for (const candidate of candidates) {
+    // Only reading and parsing may fall through to the next candidate. What the
+    // file *says* is a separate matter: once a .mcp.json has been found, a
+    // mistake inside it is reported rather than hidden behind "no config found".
+    let parsed: McpJson;
     try {
-      const raw = readFileSync(candidate, "utf-8");
-      const parsed: McpJson = JSON.parse(raw);
-      const servers: McpServerConfig[] = Object.entries(
-        parsed.mcpServers ?? {}
-      ).map(([name, cfg]) => ({
+      parsed = JSON.parse(readFileSync(candidate, "utf-8"));
+    } catch {
+      continue;
+    }
+
+    const servers: McpServerConfig[] = Object.entries(parsed.mcpServers ?? {}).map(
+      ([name, cfg]) => ({
         name,
-        type: cfg.type ?? (cfg.url ? "http" : "stdio"),
+        type: readTransport(name, cfg.type, cfg.url),
         url: cfg.url,
         command: cfg.command,
         args: cfg.args,
         env: cfg.env,
         headers: cfg.headers,
-      }));
+      }),
+    );
+    servers.forEach(assertUsable);
 
-      if (servers.length > 0) {
-        console.error(`[config] Loaded .mcp.json from ${candidate}`);
-        return servers;
-      }
-    } catch {
-      // Not found here, try next
+    if (servers.length > 0) {
+      console.error(`[config] Loaded .mcp.json from ${candidate}`);
+      return servers;
     }
   }
 
   throw new Error(
     "Could not find .mcp.json — run acp-gateway from your workspace root"
+  );
+}
+
+/**
+ * Reads an entry's transport, defaulting the way MCP clients conventionally do.
+ *
+ * An unknown transport is refused here rather than quietly treated as stdio,
+ * which produced a server with no command and an agent that could not say why.
+ */
+function readTransport(
+  name: string,
+  type: string | undefined,
+  url: string | undefined,
+): McpTransport {
+  if (type === undefined) return url ? "http" : "stdio";
+  if ((MCP_TRANSPORTS as readonly string[]).includes(type)) return type as McpTransport;
+  throw new Error(
+    `MCP server "${name}" in .mcp.json has transport "${type}", which this gateway ` +
+      `cannot hand to an agent. Use one of: ${MCP_TRANSPORTS.join(", ")}.`,
+  );
+}
+
+/**
+ * Refuses an entry the agent could never connect to.
+ *
+ * The gateway passes these straight through to the agent, so an entry missing
+ * the one field its transport needs fails inside the agent, long after the
+ * mistake was made and with nothing to point at.
+ */
+function assertUsable(server: McpServerConfig): void {
+  const missing = server.type === "stdio" ? !server.command : !server.url;
+  if (!missing) return;
+
+  const field = server.type === "stdio" ? "command" : "url";
+  throw new Error(
+    `MCP server "${server.name}" in .mcp.json is ${server.type} but has no ${field}.`,
   );
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,27 +15,75 @@ const pkg = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
 );
 
-import { loadMcpConfig, pickAgentrqServer, type McpServerConfig } from "./config.js";
+import {
+  loadMcpConfig,
+  pickAgentrqServer,
+  type McpServerConfig,
+  type McpTransport,
+} from "./config.js";
 import { MCPBridge } from "./mcpClient.js";
 
-export function mapMcpServers(configs: McpServerConfig[]): acp.McpServer[] {
-  return configs.map((cfg): acp.McpServer => {
-    if (cfg.type === "http") {
+/**
+ * What the agent said about a transport, if anything.
+ *
+ * stdio is the one transport every agent must support. For the others the
+ * answer is only trustworthy when the agent actually stated it: an agent that
+ * advertises no MCP capabilities at all is far more likely to be terse than to
+ * be unable to reach an HTTP server, and dropping its servers on that reading
+ * would take the workspace's own MCP server away from it.
+ */
+function transportSupport(
+  transport: McpTransport,
+  agentCapabilities: acp.AgentCapabilities | null | undefined,
+): "required" | "declared" | "refused" | "unstated" {
+  if (transport === "stdio") return "required";
+  const declared = (agentCapabilities?.mcpCapabilities as Record<string, unknown> | undefined)?.[
+    transport
+  ];
+  if (declared === true) return "declared";
+  if (declared === false) return "refused";
+  return "unstated";
+}
+
+export function mapMcpServers(
+  configs: McpServerConfig[],
+  agentCapabilities?: acp.AgentCapabilities | null,
+): acp.McpServer[] {
+  return configs
+    .filter((cfg) => {
+      const support = transportSupport(cfg.type, agentCapabilities);
+      if (support === "refused") {
+        console.error(
+          `[acp] ⚠️  Not passing MCP server "${cfg.name}" to the agent: it is ${cfg.type}, ` +
+            `and the agent says it does not support that transport. Passing it anyway ` +
+            `risks the agent refusing the whole session.`,
+        );
+        return false;
+      }
+      if (support === "unstated") {
+        console.error(
+          `[acp] MCP server "${cfg.name}" is ${cfg.type}, which the agent does not ` +
+            `advertise either way — passing it and letting the agent decide.`,
+        );
+      }
+      return true;
+    })
+    .map((cfg): acp.McpServer => {
+      if (cfg.type === "stdio") {
+        return {
+          name: cfg.name,
+          command: cfg.command!,
+          args: cfg.args ?? [],
+          env: Object.entries(cfg.env || {}).map(([name, value]) => ({ name, value })) as any,
+        };
+      }
       return {
-        type: "http",
+        type: cfg.type,
         name: cfg.name,
         url: cfg.url!,
         headers: Object.entries(cfg.headers || {}).map(([name, value]) => ({ name, value })) as any,
       };
-    } else {
-      return {
-        name: cfg.name,
-        command: cfg.command!,
-        args: cfg.args ?? [],
-        env: Object.entries(cfg.env || {}).map(([name, value]) => ({ name, value })) as any,
-      };
-    }
-  });
+    });
 }
 import { AgentRQACPClient } from "./acpClient.js";
 import {
@@ -233,7 +281,7 @@ export async function getOrCreateSession(
 
   const newSessionParams: AcpNewSessionParams = {
     cwd: process.cwd(),
-    mcpServers: mapMcpServers(configs),
+    mcpServers: mapMcpServers(configs, initResult.agentCapabilities),
   };
 
   const sessionResult = await createSessionWithAuth(connection, newSessionParams, {
@@ -853,6 +901,10 @@ async function main() {
           });
 
           await sessionInfo.acpClient.flushReply(sessionInfo.sessionId);
+          await sessionInfo.acpClient.reportStopReason(
+            sessionInfo.sessionId,
+            result.stopReason,
+          );
           console.error(
             `\n[acp] Agent completed task. Reason: ${result.stopReason}`,
           );
@@ -977,6 +1029,7 @@ export async function checkForNextTask(
         });
 
         await acpClientToUse!.flushReply(sessionIdToUse!);
+        await acpClientToUse!.reportStopReason(sessionIdToUse!, promptResult.stopReason);
         console.error(`\n[acp] Agent completed with: ${promptResult.stopReason}`);
       };
 


### PR DESCRIPTION
Stacked on #37.

**What changed**

Workspace MCP servers configured for the SSE transport now reach the agent as SSE instead of being mangled into a broken local-process entry, a transport the gateway cannot hand over at all is now refused with a message naming the mistake, and a server the agent has explicitly said it cannot reach is left out rather than risking the whole session. Separately, a turn that was refused or cut short now says so in the workspace instead of only in the gateway's own log.

**Why changed**

SSE is a transport ACP defines and real agents advertise, so a workspace configured that way silently got an agent with no tools. And a refused or truncated turn was indistinguishable from a completed one from the dashboard, which is exactly the case a human needs to know about.

**Test coverage report**

- New lines introduced: 100%
- Total coverage impact: statements 87.33% → 87.69%, lines 87.18% → 87.46%; 258 → 271 tests, all passing
- Transport handling is deliberately conservative: only an *explicit* refusal drops a server, because an agent that advertises nothing is likelier to be terse than unable, and dropping on silence would take the workspace's own MCP server away from it

TaskID: 0i4iswzbz8r

Generated with [AgentRQ](https://agentrq.com)