### PR TITLE
fix: stop one unanswered approval from wedging the gateway

### DIFF
--- a/src/__tests__/acpClient.test.ts
+++ b/src/__tests__/acpClient.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "node:events";
 import { AgentRQACPClient } from "../acpClient.js";
 import type { MCPBridge } from "../mcpClient.js";
 import * as fs from "node:fs/promises";
@@ -12,15 +13,26 @@ describe("AgentRQACPClient", () => {
   let mcpBridge: any;
   let client: AgentRQACPClient;
 
+  /**
+   * Answers the tool call that is waiting, the way agentrq does: by echoing
+   * back the request id the gateway actually sent.
+   */
+  function answerWith(behavior: string) {
+    setTimeout(() => {
+      const sent = mcpBridge.sendNotification.mock.calls.at(-1)?.[1];
+      mcpBridge.emit("verdict", { requestId: sent?.request_id, behavior });
+    }, 10);
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
-    mcpBridge = {
+    // A real emitter: the client registers one shared verdict listener when it
+    // is constructed, so a mocked `on` would never see a verdict at all.
+    mcpBridge = Object.assign(new EventEmitter(), {
       getSessionId: vi.fn().mockReturnValue("test-session"),
       sendNotification: vi.fn().mockResolvedValue(undefined),
       callTool: vi.fn(),
-      on: vi.fn(),
-      off: vi.fn(),
-    };
+    });
     client = new AgentRQACPClient(mcpBridge as unknown as MCPBridge);
   });
 
@@ -38,14 +50,7 @@ describe("AgentRQACPClient", () => {
         ],
       } as any;
 
-      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
-        if (event === "verdict") {
-          setTimeout(
-            () => handler({ requestId: "req-123", behavior: "allow" }),
-            10,
-          );
-        }
-      });
+      answerWith("allow");
 
       const response = await client.requestPermission(params);
       expect((response.outcome as any).optionId).toBe("opt-1");
@@ -73,8 +78,8 @@ describe("AgentRQACPClient", () => {
       // here would surface as an unhandled rejection and crash the gateway.
       const response = await client.requestPermission(params);
       expect(response.outcome.outcome).toBe("cancelled");
-      // It must not register a verdict listener it can never clean up.
-      expect(mcpBridge.on).not.toHaveBeenCalled();
+      // Nothing may be left waiting on a verdict that will never come.
+      expect(client.pendingPermissionCount).toBe(0);
 
       consoleSpy.mockRestore();
     });
@@ -96,14 +101,7 @@ describe("AgentRQACPClient", () => {
         ],
       } as any;
 
-      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
-        if (event === "verdict") {
-          setTimeout(
-            () => handler({ requestId: "req-123", behavior: "allow" }),
-            10,
-          );
-        }
-      });
+      answerWith("allow");
 
       await clientWithTaskId.requestPermission(params);
       
@@ -144,14 +142,7 @@ describe("AgentRQACPClient", () => {
         options: [{ optionId: "opt-1", kind: "allow", name: "Allow" }],
       } as any;
 
-      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
-        if (event === "verdict") {
-          setTimeout(
-            () => handler({ requestId: "req-123", behavior: "allow" }),
-            10,
-          );
-        }
-      });
+      answerWith("allow");
 
       const response = await client.requestPermission(params);
       // Permission matching still works based on behavior, independent of title presence
@@ -171,11 +162,7 @@ describe("AgentRQACPClient", () => {
         options: [{ optionId: "opt-1", kind: "allow", name: "Allow" }],
       } as any;
 
-      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
-        if (event === "verdict") {
-          setTimeout(() => handler({ requestId: "req-123", behavior: "allow" }), 10);
-        }
-      });
+      answerWith("allow");
 
       const response = await client.requestPermission(params);
       expect((response.outcome as any).optionId).toBe("opt-1");
@@ -244,11 +231,7 @@ describe("AgentRQACPClient", () => {
         ],
       } as any;
 
-      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
-        if (event === "verdict") {
-          setTimeout(() => handler({ requestId: "call_abc", behavior: "allow" }), 10);
-        }
-      });
+      answerWith("allow");
 
       await client.requestPermission(params);
 
@@ -288,11 +271,7 @@ describe("AgentRQACPClient", () => {
         ],
       } as any;
 
-      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
-        if (event === "verdict") {
-          setTimeout(() => handler({ requestId: "call_cmd", behavior: "allow" }), 10);
-        }
-      });
+      answerWith("allow");
 
       await client.requestPermission(params);
 
@@ -315,11 +294,7 @@ describe("AgentRQACPClient", () => {
         ],
       } as any;
 
-      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
-        if (event === "verdict") {
-          setTimeout(() => handler({ requestId: "call_unseen", behavior: "allow" }), 10);
-        }
-      });
+      answerWith("allow");
 
       await client.requestPermission(params);
 
@@ -350,11 +325,7 @@ describe("AgentRQACPClient", () => {
         ],
       } as any;
 
-      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
-        if (event === "verdict") {
-          setTimeout(() => handler({ requestId: "call_done", behavior: "allow" }), 10);
-        }
-      });
+      answerWith("allow");
 
       await client.requestPermission(params);
 
@@ -392,11 +363,7 @@ describe("AgentRQACPClient", () => {
       expect(mcpBridge.sendNotification).not.toHaveBeenCalled();
 
       // A replay of the same id no longer resolves, so it reaches the human.
-      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
-        if (event === "verdict") {
-          setTimeout(() => handler({ requestId: "call_once", behavior: "allow" }), 10);
-        }
-      });
+      answerWith("allow");
       await client.requestPermission(params);
       expect(mcpBridge.sendNotification).toHaveBeenCalledWith(
         expect.any(String),
@@ -459,11 +426,7 @@ describe("AgentRQACPClient", () => {
         ],
       } as any;
 
-      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
-        if (event === "verdict") {
-          setTimeout(() => handler({ requestId: "call_bare", behavior: "allow" }), 10);
-        }
-      });
+      answerWith("allow");
 
       await client.requestPermission(params);
 
@@ -491,14 +454,7 @@ describe("AgentRQACPClient", () => {
         ],
       } as any;
 
-      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
-        if (event === "verdict") {
-          setTimeout(
-            () => handler({ requestId: "req-123", behavior: "allow" }),
-            10,
-          );
-        }
-      });
+      answerWith("allow");
 
       const response = await client.requestPermission(params);
       expect((response.outcome as any).optionId).toBe("opt-1");
@@ -513,14 +469,7 @@ describe("AgentRQACPClient", () => {
         ],
       } as any;
 
-      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
-        if (event === "verdict") {
-          setTimeout(
-            () => handler({ requestId: "req-123", behavior: "deny" }),
-            10,
-          );
-        }
-      });
+      answerWith("deny");
 
       const response = await client.requestPermission(params);
       expect((response.outcome as any).optionId).toBe("opt-2");
@@ -535,14 +484,7 @@ describe("AgentRQACPClient", () => {
         ],
       } as any;
 
-      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
-        if (event === "verdict") {
-          setTimeout(
-            () => handler({ requestId: "req-123", behavior: "deny" }),
-            10,
-          );
-        }
-      });
+      answerWith("deny");
 
       const response = await client.requestPermission(params);
       expect((response.outcome as any).optionId).toBe("opt-1");
@@ -557,14 +499,7 @@ describe("AgentRQACPClient", () => {
         ],
       } as any;
 
-      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
-        if (event === "verdict") {
-          setTimeout(
-            () => handler({ requestId: "req-123", behavior: "deny" }),
-            10,
-          );
-        }
-      });
+      answerWith("deny");
 
       const response = await client.requestPermission(params);
       // A spec-compliant "reject_once" kind must never be missed and fall
@@ -582,14 +517,7 @@ describe("AgentRQACPClient", () => {
         ],
       } as any;
 
-      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
-        if (event === "verdict") {
-          setTimeout(
-            () => handler({ requestId: "req-123", behavior: "deny" }),
-            10,
-          );
-        }
-      });
+      answerWith("deny");
 
       const response = await client.requestPermission(params);
       expect((response.outcome as any).optionId).toBe("opt-2");
@@ -601,14 +529,7 @@ describe("AgentRQACPClient", () => {
         options: [{ optionId: "opt-1", kind: "allow_once", name: "Proceed" }],
       } as any;
 
-      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
-        if (event === "verdict") {
-          setTimeout(
-            () => handler({ requestId: "req-123", behavior: "deny" }),
-            10,
-          );
-        }
-      });
+      answerWith("deny");
 
       const response = await client.requestPermission(params);
       expect(response.outcome.outcome).toBe("cancelled");
@@ -623,14 +544,7 @@ describe("AgentRQACPClient", () => {
         ],
       } as any;
 
-      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
-        if (event === "verdict") {
-          setTimeout(
-            () => handler({ requestId: "req-123", behavior: "allow" }),
-            10,
-          );
-        }
-      });
+      answerWith("allow");
 
       const response = await client.requestPermission(params);
       // Selecting "allow_always" would make the spawned agent remember this
@@ -648,14 +562,7 @@ describe("AgentRQACPClient", () => {
         ],
       } as any;
 
-      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
-        if (event === "verdict") {
-          setTimeout(
-            () => handler({ requestId: "req-123", behavior: "deny" }),
-            10,
-          );
-        }
-      });
+      answerWith("deny");
 
       const response = await client.requestPermission(params);
       expect((response.outcome as any).optionId).toBe("opt-once");
@@ -667,14 +574,7 @@ describe("AgentRQACPClient", () => {
         options: [{ optionId: "opt-always", kind: "allow_always", name: "Always Allow" }],
       } as any;
 
-      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
-        if (event === "verdict") {
-          setTimeout(
-            () => handler({ requestId: "req-123", behavior: "allow" }),
-            10,
-          );
-        }
-      });
+      answerWith("allow");
 
       const response = await client.requestPermission(params);
       expect(response.outcome.outcome).toBe("cancelled");
@@ -686,14 +586,7 @@ describe("AgentRQACPClient", () => {
         options: [{ optionId: "opt-default", kind: "other", name: "Maybe" }],
       } as any;
 
-      mcpBridge.on.mockImplementation((event: string, handler: Function) => {
-        if (event === "verdict") {
-          setTimeout(
-            () => handler({ requestId: "req-123", behavior: "allow" }),
-            10,
-          );
-        }
-      });
+      answerWith("allow");
 
       const response = await client.requestPermission(params);
       expect((response.outcome as any).optionId).toBe("opt-default");
@@ -1104,6 +997,130 @@ describe("AgentRQACPClient", () => {
       await c.flushReply("sess-1");
 
       expect(mcpBridge.callTool).toHaveBeenCalledWith("reply", { chatId: "task-123", text: "Hello world" });
+    });
+  });
+
+  describe("waiting for a verdict", () => {
+    const params = (overrides: Record<string, any> = {}) => ({
+      sessionId: "sess-1",
+      toolCall: { toolCallId: "call-1", title: "Bash", rawInput: { command: "ls" } },
+      options: [
+        { optionId: "opt-1", kind: "allow_once", name: "Allow" },
+        { optionId: "opt-2", kind: "reject_once", name: "Deny" },
+      ],
+      ...overrides,
+    }) as any;
+
+    it("should scope the request id to the session it came from", async () => {
+      answerWith("allow");
+      await client.requestPermission(params());
+
+      // agentrq keys its bookkeeping on the request id alone, workspace-wide,
+      // while tool call ids are only unique within one session.
+      expect(mcpBridge.sendNotification.mock.calls[0][1].request_id).toBe("sess-1:call-1");
+    });
+
+    it("should fall back to the bare tool call id when there is no session", async () => {
+      answerWith("allow");
+      await client.requestPermission(params({ sessionId: undefined }));
+
+      expect(mcpBridge.sendNotification.mock.calls[0][1].request_id).toBe("call-1");
+    });
+
+    it("should keep one verdict listener however many calls are waiting", async () => {
+      const waiting = [
+        client.requestPermission(params()),
+        client.requestPermission(params({ toolCall: { toolCallId: "call-2", title: "Bash" } })),
+        client.requestPermission(params({ toolCall: { toolCallId: "call-3", title: "Bash" } })),
+      ];
+      await vi.waitFor(() => expect(client.pendingPermissionCount).toBe(3));
+
+      // A listener per request was only ever removed on a matching verdict, so
+      // every unanswered request leaked one for the life of the process.
+      expect(mcpBridge.listenerCount("verdict")).toBe(1);
+
+      client.cancelPendingPermissions("test");
+      await Promise.all(waiting);
+      expect(client.pendingPermissionCount).toBe(0);
+    });
+
+    it("should ignore a verdict for a call that is not waiting", async () => {
+      answerWith("allow");
+      await client.requestPermission(params());
+
+      expect(() => mcpBridge.emit("verdict", { requestId: "gone", behavior: "allow" })).not.toThrow();
+    });
+
+    it("should give up on a call nobody answers, and stop the turn", async () => {
+      vi.useFakeTimers();
+      const cancel = vi.fn();
+      const bounded = new AgentRQACPClient(mcpBridge as unknown as MCPBridge, () => "task-1", {
+        permissionTimeoutMs: 60_000,
+      });
+      bounded.setSessionCanceller(cancel);
+
+      const waiting = bounded.requestPermission(params());
+      await vi.waitFor(() => expect(bounded.pendingPermissionCount).toBe(1));
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      // Cancelling as well as answering: the spec treats "cancelled" as the
+      // answer a client gives because it cancelled the turn. Answering alone
+      // would leave the agent free to carry on and ask again.
+      expect((await waiting).outcome.outcome).toBe("cancelled");
+      expect(cancel).toHaveBeenCalledWith("sess-1");
+      expect(bounded.pendingPermissionCount).toBe(0);
+      vi.useRealTimers();
+    });
+
+    it("should survive a turn that cannot be cancelled", async () => {
+      vi.useFakeTimers();
+      const bounded = new AgentRQACPClient(mcpBridge as unknown as MCPBridge, () => "task-1", {
+        permissionTimeoutMs: 60_000,
+      });
+      bounded.setSessionCanceller(() => {
+        throw new Error("connection gone");
+      });
+
+      const waiting = bounded.requestPermission(params());
+      await vi.waitFor(() => expect(bounded.pendingPermissionCount).toBe(1));
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect((await waiting).outcome.outcome).toBe("cancelled");
+      vi.useRealTimers();
+    });
+
+    it("should wait indefinitely when the timeout is switched off", async () => {
+      vi.useFakeTimers();
+      const unbounded = new AgentRQACPClient(mcpBridge as unknown as MCPBridge, () => "task-1", {
+        permissionTimeoutMs: 0,
+      });
+
+      const waiting = unbounded.requestPermission(params());
+      await vi.waitFor(() => expect(unbounded.pendingPermissionCount).toBe(1));
+      await vi.advanceTimersByTimeAsync(24 * 60 * 60_000);
+
+      expect(unbounded.pendingPermissionCount).toBe(1);
+      unbounded.cancelPendingPermissions("test over");
+      expect((await waiting).outcome.outcome).toBe("cancelled");
+      vi.useRealTimers();
+    });
+
+    it("should answer everything still waiting when the agent is gone", async () => {
+      const waiting = client.requestPermission(params());
+      await vi.waitFor(() => expect(client.pendingPermissionCount).toBe(1));
+
+      client.cancelPendingPermissions("agent process exited");
+
+      expect((await waiting).outcome.outcome).toBe("cancelled");
+      expect(client.pendingPermissionCount).toBe(0);
+    });
+
+    it("should say nothing when there is nothing waiting to cancel", () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      client.cancelPendingPermissions("nothing doing");
+
+      expect(errorSpy).not.toHaveBeenCalled();
+      errorSpy.mockRestore();
     });
   });
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -27,6 +27,16 @@ import {
 import { AUTH_REQUIRED_CODE } from "../auth.js";
 import type { McpServerConfig } from "../config.js";
 
+/**
+ * A stand-in for the workspace bridge.
+ *
+ * The ACP client registers a verdict listener on it as soon as it is built, so
+ * a bare object is not enough — the real bridge is an EventEmitter.
+ */
+function fakeBridge(): any {
+  return new EventEmitter();
+}
+
 // Real emitters so the agent-process lifecycle handlers can be exercised.
 const { spawnedAgents } = vi.hoisted(() => ({ spawnedAgents: [] as any[] }));
 
@@ -463,7 +473,7 @@ describe("index", () => {
     });
 
     it("should spawn a new session when not cached", async () => {
-      const mockBridge: any = {};
+      const mockBridge: any = fakeBridge();
       const configs: any[] = [];
       const agentrqConfig: any = { env: {} };
       
@@ -475,7 +485,7 @@ describe("index", () => {
     });
 
     it("should return cached session when already created", async () => {
-      const mockBridge: any = {};
+      const mockBridge: any = fakeBridge();
       const configs: any[] = [];
       const agentrqConfig: any = { env: {} };
 
@@ -486,7 +496,7 @@ describe("index", () => {
     });
 
     it("should declare elicitation support when initializing the ACP connection", async () => {
-      const mockBridge: any = {};
+      const mockBridge: any = fakeBridge();
       const configs: any[] = [];
       const agentrqConfig: any = { env: {} };
 
@@ -502,7 +512,7 @@ describe("index", () => {
     });
 
     it("should declare whether it can host a terminal login", async () => {
-      const mockBridge: any = {};
+      const mockBridge: any = fakeBridge();
 
       const session = await getOrCreateSession("T-Auth-Cap", ["node", "agent.js"], [], { env: {} } as any, mockBridge);
 
@@ -535,7 +545,7 @@ describe("index", () => {
         } as any;
       } as any);
 
-      const session = await getOrCreateSession("T-Login", ["node", "agent.js"], [], { env: {} } as any, {} as any);
+      const session = await getOrCreateSession("T-Login", ["node", "agent.js"], [], { env: {} } as any, fakeBridge());
 
       expect(authenticate).toHaveBeenCalledWith({ methodId: "agent-login" });
       expect(newSession).toHaveBeenCalledTimes(2);
@@ -543,7 +553,7 @@ describe("index", () => {
     });
 
     it("should drop the cached session when the agent process dies", async () => {
-      const mockBridge: any = {};
+      const mockBridge: any = fakeBridge();
       await getOrCreateSession("T-Exit", ["node", "agent.js"], [], { env: {} } as any, mockBridge);
       expect(activeSessions.has("T-Exit")).toBe(true);
 
@@ -571,7 +581,7 @@ describe("index", () => {
       const onExit = vi.fn();
       const agent = await openAgentConnection({
         acpCmdArgs: ["node", "agent.js"],
-        mcpBridge: {} as any,
+        mcpBridge: fakeBridge(),
         label: "login",
         onExit,
       });
@@ -622,10 +632,27 @@ describe("index", () => {
     it("should default to bridging tasks with a concurrency of 2", () => {
       expect(parseGatewayArgs([])).toEqual({
         maxConcurrency: 2,
+        permissionTimeoutMs: 30 * 60_000,
         command: "run",
         allowUnverifiedAgent: false,
         rest: [],
       });
+    });
+
+    it("should take the permission timeout in minutes", () => {
+      expect(parseGatewayArgs(["--permission-timeout", "5"]).permissionTimeoutMs).toBe(300_000);
+      // Zero is a deliberate "wait indefinitely", so it must not be ignored.
+      expect(parseGatewayArgs(["--permission-timeout", "0"]).permissionTimeoutMs).toBe(0);
+    });
+
+    it("should keep the default when the timeout makes no sense", () => {
+      expect(parseGatewayArgs(["--permission-timeout"]).permissionTimeoutMs).toBe(30 * 60_000);
+      expect(parseGatewayArgs(["--permission-timeout", "soon"]).permissionTimeoutMs).toBe(
+        30 * 60_000,
+      );
+      expect(parseGatewayArgs(["--permission-timeout", "-5"]).permissionTimeoutMs).toBe(
+        30 * 60_000,
+      );
     });
 
     it("should accept both spellings of the concurrency flag", () => {
@@ -778,6 +805,7 @@ describe("index", () => {
   describe("resolveAgentCommand", () => {
     const options = (overrides: Record<string, any> = {}) => ({
       maxConcurrency: 2,
+      permissionTimeoutMs: 30 * 60_000,
       command: "run" as const,
       allowUnverifiedAgent: false,
       rest: [],
@@ -865,7 +893,7 @@ describe("index", () => {
         agentCapabilities: { auth: { logout: {} } },
       });
 
-      await runAgentCommand("list-auth-methods", ["gemini", "--acp"], agentrqConfig, {} as any);
+      await runAgentCommand("list-auth-methods", ["gemini", "--acp"], agentrqConfig, fakeBridge());
 
       const printed = logSpy.mock.calls.flat().join("\n");
       expect(printed).toContain("Agent login (agent-login)");
@@ -883,7 +911,7 @@ describe("index", () => {
         },
       });
 
-      await runAgentCommand("agent-info", ["gemini", "--acp"], agentrqConfig, {} as any);
+      await runAgentCommand("agent-info", ["gemini", "--acp"], agentrqConfig, fakeBridge());
 
       const printed = String(logSpy.mock.calls.at(-1)[0]);
       expect(printed).toContain("gemini --acp");
@@ -897,7 +925,7 @@ describe("index", () => {
     it("should report agents that advertise no login", async () => {
       mockConnection({});
 
-      await runAgentCommand("list-auth-methods", ["gemini", "--acp"], agentrqConfig, {} as any);
+      await runAgentCommand("list-auth-methods", ["gemini", "--acp"], agentrqConfig, fakeBridge());
 
       expect(logSpy.mock.calls.flat().join("\n")).toContain("no authentication methods");
     });
@@ -907,7 +935,7 @@ describe("index", () => {
         agentCapabilities: { auth: { logout: {} } },
       });
 
-      await runAgentCommand("logout", ["gemini", "--acp"], agentrqConfig, {} as any);
+      await runAgentCommand("logout", ["gemini", "--acp"], agentrqConfig, fakeBridge());
 
       expect(connection.logout).toHaveBeenCalledWith({});
     });
@@ -920,7 +948,7 @@ describe("index", () => {
         ],
       });
 
-      await runAgentCommand("login", ["gemini", "--acp"], agentrqConfig, {} as any, "oauth");
+      await runAgentCommand("login", ["gemini", "--acp"], agentrqConfig, fakeBridge(), "oauth");
 
       expect(connection.authenticate).toHaveBeenCalledWith({ methodId: "oauth" });
     });
@@ -931,7 +959,7 @@ describe("index", () => {
       });
 
       await expect(
-        runAgentCommand("login", ["gemini", "--acp"], agentrqConfig, {} as any, "missing"),
+        runAgentCommand("login", ["gemini", "--acp"], agentrqConfig, fakeBridge(), "missing"),
       ).rejects.toThrow(/Unknown authentication method/);
       expect(spawnedAgents[0].kill).toHaveBeenCalled();
     });
@@ -956,6 +984,7 @@ describe("index", () => {
           "--logout",
           "--auth-method",
           "--max-concurrency",
+          "--permission-timeout",
           "--help",
         ]),
       );

--- a/src/acpClient.ts
+++ b/src/acpClient.ts
@@ -19,6 +19,25 @@ const AGENTRQ_TOOL_PATTERN = /agentrq-[a-zA-Z0-9]{11}/;
  * Without this the workspace sees the agent's partial answer and nothing else,
  * so a refused or truncated turn is indistinguishable from a finished one.
  */
+/**
+ * How long a tool call waits for a human before the turn is given up on.
+ *
+ * Humans are slow — this is not a network timeout — but it must exist: a wait
+ * with no end holds a task-queue slot for the life of the process, and at low
+ * concurrency one unanswered approval is enough to stop the workspace.
+ */
+export const DEFAULT_PERMISSION_TIMEOUT_MS = 30 * 60 * 1000;
+
+/** A permission request that has been sent to agentrq and has no verdict yet. */
+interface PendingPermission {
+  /** Exactly what was sent, kept so it can be re-sent if the session changes. */
+  payload: Record<string, unknown>;
+  sessionId?: string;
+  options: acp.PermissionOption[];
+  /** Answers the agent once, and forgets the request. */
+  settle: (outcome: acp.RequestPermissionOutcome) => void;
+}
+
 const STOP_REASON_NOTES: Record<string, string> = {
   refusal: "⚠️ The agent refused to continue this turn.",
   max_tokens: "⚠️ The agent stopped mid-turn: it ran out of output tokens.",
@@ -37,10 +56,71 @@ export class AgentRQACPClient implements acp.Client {
   // otherwise leave us unable to tell an agentrq MCP call from anything else.
   private toolCallDetails = new Map<string, { title?: string; rawInput?: unknown }>();
 
+  // request_id → the tool call waiting on a human. One shared verdict listener
+  // serves them all: a listener per request was only ever removed on a matching
+  // verdict, so every unanswered request leaked one for the life of the process.
+  private pendingPermissions = new Map<string, PendingPermission>();
+  private permissionTimeoutMs: number;
+  private cancelSession?: (sessionId: string) => unknown;
+
   constructor(
     private mcpBridge: MCPBridge,
     private getTaskIdForSession: (sessionId: string) => string | undefined = () => undefined,
-  ) {}
+    options: { permissionTimeoutMs?: number } = {},
+  ) {
+    this.permissionTimeoutMs = options.permissionTimeoutMs ?? DEFAULT_PERMISSION_TIMEOUT_MS;
+    this.mcpBridge.on("verdict", this.onVerdict);
+  }
+
+  /** How many tool calls are waiting on a human right now. */
+  get pendingPermissionCount(): number {
+    return this.pendingPermissions.size;
+  }
+
+  /**
+   * Supplies the way to stop a turn, which only exists once the agent
+   * connection has been built around this client.
+   */
+  setSessionCanceller(cancel: (sessionId: string) => unknown): void {
+    this.cancelSession = cancel;
+  }
+
+  /**
+   * Answers every waiting tool call with `cancelled`.
+   *
+   * Used when the agent is gone: nothing will ever act on those answers, but
+   * the promises must settle or their task-queue slots are held forever.
+   */
+  cancelPendingPermissions(reason: string): void {
+    if (this.pendingPermissions.size === 0) return;
+    console.error(
+      `[acp] Cancelling ${this.pendingPermissions.size} waiting permission request(s): ${reason}`,
+    );
+    for (const pending of [...this.pendingPermissions.values()]) {
+      pending.settle({ outcome: "cancelled" });
+    }
+  }
+
+  /** Delivers a verdict to whichever tool call is waiting on it, if any. */
+  private onVerdict = (data: { requestId: string; behavior: string }): void => {
+    const pending = this.pendingPermissions.get(data.requestId);
+    if (!pending) {
+      console.error(`[acp] Verdict for ${data.requestId} arrived with nothing waiting on it`);
+      return;
+    }
+    console.error(`✅ Permission verdict received: ${data.behavior}`);
+    pending.settle(this.outcomeForVerdict(pending.options, data.behavior));
+  };
+
+  /** Stops the agent's current turn, where there is a connection to stop it on. */
+  private async cancelTurn(sessionId: string | undefined): Promise<void> {
+    if (!sessionId || !this.cancelSession) return;
+    try {
+      await this.cancelSession(sessionId);
+    } catch (err) {
+      console.error(`[acp] Failed to cancel turn for session ${sessionId}:`, err);
+    }
+  }
 
   async flushReply(sessionId: string): Promise<void> {
     const text = this.replyBuffers.get(sessionId) ?? "";
@@ -97,21 +177,21 @@ export class AgentRQACPClient implements acp.Client {
   async requestPermission(
     params: acp.RequestPermissionRequest
   ): Promise<acp.RequestPermissionResponse> {
-    const requestId = params.toolCall.toolCallId;
+    const toolCallId = params.toolCall.toolCallId;
     // Fall back to what the earlier session update reported for this same tool
     // call: the permission request itself may carry no title or input.
-    const remembered = this.toolCallDetails.get(requestId);
-    this.toolCallDetails.delete(requestId);
+    const remembered = this.toolCallDetails.get(toolCallId);
+    this.toolCallDetails.delete(toolCallId);
     const toolTitle = params.toolCall.title ?? remembered?.title ?? "Unknown Tool";
     const rawInput = params.toolCall.rawInput ?? remembered?.rawInput;
 
     // Auto-allow tool calls that contain the pattern: agentrq-<11 chars a-zA-Z0-9>
     if (AGENTRQ_TOOL_PATTERN.test(toolTitle)) {
-      console.error(`\n🔓 ACP Auto-allowing tool call: ${toolTitle} (ID: ${requestId})`);
-      const option = params.options.find(o => 
+      console.error(`\n🔓 ACP Auto-allowing tool call: ${toolTitle} (ID: ${toolCallId})`);
+      const option = params.options.find(o =>
         o.kind.startsWith("allow") ||
-        o.name.toLowerCase().includes("allow") || 
-        o.name.toLowerCase().includes("yes") || 
+        o.name.toLowerCase().includes("allow") ||
+        o.name.toLowerCase().includes("yes") ||
         o.name.toLowerCase().includes("approve")
       );
       const optionId = option?.optionId ?? params.options[0].optionId;
@@ -123,9 +203,15 @@ export class AgentRQACPClient implements acp.Client {
       };
     }
 
-    console.error(`\n🔐 ACP Permission requested: ${toolTitle} (ID: ${requestId})`);
+    console.error(`\n🔐 ACP Permission requested: ${toolTitle} (ID: ${toolCallId})`);
 
-    const taskId = params.sessionId ? this.getTaskIdForSession(params.sessionId) : undefined;
+    const sessionId = params.sessionId as string | undefined;
+    // agentrq keys its own bookkeeping on the request id alone, across the whole
+    // workspace. Tool call ids are only unique within a session, and agents
+    // commonly number them from one, so two tasks running at once could
+    // otherwise have a verdict land on the wrong tool call.
+    const requestId = sessionId ? `${sessionId}:${toolCallId}` : toolCallId;
+    const taskId = sessionId ? this.getTaskIdForSession(sessionId) : undefined;
     const payload = {
       request_id: requestId,
       task_id: taskId,
@@ -155,71 +241,90 @@ export class AgentRQACPClient implements acp.Client {
       return { outcome: { outcome: "cancelled" } };
     }
 
-    // 2. Wait for the verdict from the MCP server
+    // 2. Wait for the verdict from the MCP server — but not forever.
     console.error(`⌛ Waiting for human approval in the agentrq dashboard...`);
-    
-    return new Promise((resolve) => {
-      const handler = (data: { requestId: string; behavior: string }) => {
-        if (data.requestId === requestId) {
-          // Cleanup this listener
-          this.mcpBridge.off("verdict", handler);
-          
-          console.error(`✅ Permission verdict received: ${data.behavior}`);
 
-          // A verdict from agentrq covers exactly one tool call. Never select
-          // a "persistent" option (ACP's "allow_always"/"reject_always" kinds,
-          // or an equivalent "remember"/"don't ask again" option by name) —
-          // picking one would make the *spawned agent* remember the decision
-          // and stop sending requestPermission for matching future tool
-          // calls, so those calls would never reach agentrq again. Every
-          // subsequent call must still be forwarded and re-approved there.
-          const isPersistent = (o: acp.PermissionOption) =>
-            /always|remember|don'?t ask/i.test(o.kind) || /always|remember|don'?t ask/i.test(o.name);
-          const onceOptions = params.options.filter(o => !isPersistent(o));
+    return new Promise<acp.RequestPermissionResponse>((resolve) => {
+      const timer =
+        this.permissionTimeoutMs > 0
+          ? setTimeout(() => {
+              console.error(
+                `[acp] ⌛ No verdict for ${requestId} after ` +
+                  `${Math.round(this.permissionTimeoutMs / 60000)} min — cancelling the turn.`,
+              );
+              // Cancel as well as answering: the spec treats `cancelled` as the
+              // answer a client gives *because* it cancelled the turn. Answering
+              // alone would leave the agent free to carry on and ask again.
+              void this.cancelTurn(sessionId);
+              settle({ outcome: "cancelled" });
+            }, this.permissionTimeoutMs)
+          : undefined;
 
-          // Map "allow"/"deny" to the correct ACP option. Per the ACP spec,
-          // PermissionOptionKind is one of "allow_once" | "allow_always" |
-          // "reject_once" | "reject_always" — there is no "deny_*" kind, so a
-          // deny verdict must match on "reject" to find a spec-compliant option.
-          const isAllow = data.behavior === "allow";
-          const option = onceOptions.find(o => {
-            const name = o.name.toLowerCase();
-            return isAllow
-              ? o.kind.startsWith("allow") || name.includes("allow") || name.includes("yes") || name.includes("approve")
-              : o.kind.startsWith("reject") || name.includes("deny") || name.includes("reject") || name.includes("no");
-          });
-
-          // Falling back to onceOptions[0] unconditionally is unsafe for a
-          // deny verdict: ACP conventionally lists allow options first, so an
-          // unmatched deny could silently resolve to an allow option and
-          // approve a tool call the human explicitly denied. Only ever fall
-          // back to a non-persistent option that is not itself an allow-kind;
-          // if no safe option exists at all (e.g. only "always" options were
-          // offered), cancel instead of guessing.
-          let outcome: acp.RequestPermissionOutcome;
-          if (option) {
-            outcome = { outcome: "selected", optionId: option.optionId };
-          } else if (isAllow) {
-            outcome = onceOptions[0]
-              ? { outcome: "selected", optionId: onceOptions[0].optionId }
-              : { outcome: "cancelled" };
-          } else {
-            const safeFallback = onceOptions.find(o => !o.kind.startsWith("allow"));
-            outcome = safeFallback
-              ? { outcome: "selected", optionId: safeFallback.optionId }
-              : { outcome: "cancelled" };
-          }
-
-          console.error(
-            `[acp] Selected permission option: ${"optionId" in outcome ? outcome.optionId : "cancelled"} (${option?.name ?? "default"})`
-          );
-
-          resolve({ outcome });
-        }
+      const settle = (outcome: acp.RequestPermissionOutcome): void => {
+        if (timer) clearTimeout(timer);
+        this.pendingPermissions.delete(requestId);
+        console.error(
+          `[acp] Selected permission option: ${"optionId" in outcome ? outcome.optionId : "cancelled"}`,
+        );
+        resolve({ outcome });
       };
 
-      this.mcpBridge.on("verdict", handler);
+      this.pendingPermissions.set(requestId, {
+        payload,
+        sessionId,
+        options: params.options,
+        settle,
+      });
     });
+  }
+
+  /**
+   * Turns a workspace verdict into one of the options the agent offered.
+   *
+   * A verdict from agentrq covers exactly one tool call. Never select a
+   * "persistent" option (ACP's "allow_always"/"reject_always" kinds, or an
+   * equivalent "remember"/"don't ask again" option by name) — picking one would
+   * make the *spawned agent* remember the decision and stop sending
+   * requestPermission for matching future tool calls, so those calls would
+   * never reach agentrq again. Every subsequent call must still be forwarded
+   * and re-approved there.
+   */
+  private outcomeForVerdict(
+    options: acp.PermissionOption[],
+    behavior: string,
+  ): acp.RequestPermissionOutcome {
+    const isPersistent = (o: acp.PermissionOption) =>
+      /always|remember|don'?t ask/i.test(o.kind) || /always|remember|don'?t ask/i.test(o.name);
+    const onceOptions = options.filter(o => !isPersistent(o));
+
+    // Map "allow"/"deny" to the correct ACP option. Per the ACP spec,
+    // PermissionOptionKind is one of "allow_once" | "allow_always" |
+    // "reject_once" | "reject_always" — there is no "deny_*" kind, so a
+    // deny verdict must match on "reject" to find a spec-compliant option.
+    const isAllow = behavior === "allow";
+    const option = onceOptions.find(o => {
+      const name = o.name.toLowerCase();
+      return isAllow
+        ? o.kind.startsWith("allow") || name.includes("allow") || name.includes("yes") || name.includes("approve")
+        : o.kind.startsWith("reject") || name.includes("deny") || name.includes("reject") || name.includes("no");
+    });
+    if (option) return { outcome: "selected", optionId: option.optionId };
+
+    // Falling back to onceOptions[0] unconditionally is unsafe for a deny
+    // verdict: ACP conventionally lists allow options first, so an unmatched
+    // deny could silently resolve to an allow option and approve a tool call
+    // the human explicitly denied. Only ever fall back to a non-persistent
+    // option that is not itself an allow-kind; if no safe option exists at all
+    // (e.g. only "always" options were offered), cancel instead of guessing.
+    if (isAllow) {
+      return onceOptions[0]
+        ? { outcome: "selected", optionId: onceOptions[0].optionId }
+        : { outcome: "cancelled" };
+    }
+    const safeFallback = onceOptions.find(o => !o.kind.startsWith("allow"));
+    return safeFallback
+      ? { outcome: "selected", optionId: safeFallback.optionId }
+      : { outcome: "cancelled" };
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ export function mapMcpServers(
       };
     });
 }
-import { AgentRQACPClient } from "./acpClient.js";
+import { AgentRQACPClient, DEFAULT_PERMISSION_TIMEOUT_MS } from "./acpClient.js";
 import {
   describeAuthMethods,
   isAuthRequiredError,
@@ -121,6 +121,9 @@ export const activeSessions = new Map<string, AgentSession>();
 
 /** Login preferences taken from the CLI, consulted whenever an agent demands auth. */
 export const authConfig: { methodId?: string } = {};
+
+/** How long tool calls wait for a human, taken from the CLI at startup. */
+export const permissionConfig: { timeoutMs?: number } = {};
 
 /**
  * Whether a human is sitting in front of this process.
@@ -172,17 +175,25 @@ export async function openAgentConnection({
     env: { ...process.env, ...env },
   });
 
+  const acpClient = new AgentRQACPClient(mcpBridge, () => taskId, {
+    permissionTimeoutMs: permissionConfig.timeoutMs,
+  });
+
   // Guard against unhandled child-process failures. Without these listeners a
   // crashed agent (e.g. on network loss) leaves a broken stdin pipe; the next
   // write raises EPIPE as an uncaught error and takes the gateway down with it.
   agentProcess.on("error", (err: Error) => {
     console.error(`[acp] Agent process error for ${label}:`, err.message);
+    acpClient.cancelPendingPermissions(`agent process for ${label} failed`);
     onExit?.();
   });
   agentProcess.on("exit", (code: number | null, signal: string | null) => {
     console.error(
       `[acp] Agent process for ${label} exited (code=${code}, signal=${signal})`,
     );
+    // Nothing will act on these answers now, but the tool calls waiting on them
+    // are holding task-queue slots that would never be given back.
+    acpClient.cancelPendingPermissions(`agent process for ${label} exited`);
     onExit?.();
   });
   // stdin can emit EPIPE when the child dies mid-write; swallow it so it
@@ -196,12 +207,14 @@ export async function openAgentConnection({
     agentProcess.stdout!,
   ) as ReadableStream<Uint8Array>;
 
-  const acpClient = new AgentRQACPClient(mcpBridge, () => taskId);
   const stream = acp.ndJsonStream(input, output);
   const connection = new acp.ClientSideConnection(
     (_agent) => acpClient,
     stream,
   );
+  // Stopping a turn is only possible once the connection exists, and the
+  // connection is built around the client — so it is handed over afterwards.
+  acpClient.setSessionCanceller((sessionId) => connection.cancel({ sessionId }));
 
   const initResult = await connection.initialize({
     protocolVersion: acp.PROTOCOL_VERSION,
@@ -487,6 +500,8 @@ export type GatewayCommand =
 
 export interface GatewayOptions {
   maxConcurrency: number;
+  /** How long a tool call waits for a human verdict. 0 waits indefinitely. */
+  permissionTimeoutMs: number;
   authMethodId?: string;
   command: GatewayCommand;
   /** Registry id of the agent to run, instead of a command given after `--`. */
@@ -506,6 +521,7 @@ export interface GatewayOptions {
 export function parseGatewayArgs(args: string[]): GatewayOptions {
   const options: GatewayOptions = {
     maxConcurrency: 2,
+    permissionTimeoutMs: DEFAULT_PERMISSION_TIMEOUT_MS,
     command: "run",
     allowUnverifiedAgent: false,
     rest: [],
@@ -523,6 +539,14 @@ export function parseGatewayArgs(args: string[]): GatewayOptions {
         const parsed = parseInt(value ?? "", 10);
         if (!isNaN(parsed)) {
           options.maxConcurrency = parsed;
+          i++;
+        }
+        break;
+      }
+      case "--permission-timeout": {
+        const minutes = parseInt(value ?? "", 10);
+        if (!isNaN(minutes) && minutes >= 0) {
+          options.permissionTimeoutMs = minutes * 60_000;
           i++;
         }
         break;
@@ -766,6 +790,10 @@ AUTHENTICATION
 BRIDGE
   --max-concurrency <number>  How many tasks may prompt the agent at once.
                               Defaults to 2.
+  --permission-timeout <min>  How long a tool call waits for someone to approve
+                              it before the turn is cancelled. Defaults to 30.
+                              0 waits indefinitely, which is what a wedged
+                              gateway looks like — use it knowingly.
 
 OTHER
   --help, -h                  Show this help. Exits.
@@ -849,6 +877,7 @@ async function main() {
   }
 
   authConfig.methodId = authMethodId;
+  permissionConfig.timeoutMs = options.permissionTimeoutMs;
 
   const taskQueue = new TaskQueue(maxConcurrency);
 


### PR DESCRIPTION
Stacked on #38.

**What changed**

A tool call waiting for someone to approve it now gives up after a configurable wait — thirty minutes by default — cancelling the agent's turn rather than waiting forever. Everything still waiting is answered when the agent goes away, one shared listener now serves every waiting call instead of one per call that was never cleaned up, and each request is identified by the session it came from as well as the tool call.

**Why changed**

The wait had no end and no cancel path, so a single unanswered approval — or one lost when the connection to the workspace was re-established — held its slot for the life of the process. At low concurrency that is enough to stop the workspace entirely, with no error and nothing in the logs to say why. The per-call listeners leaked alongside it. Separately, request ids were only unique within one session while the workspace treats them as unique across the whole thing, so two tasks running at once could have an approval land on the wrong command.

**Test coverage report**

- New lines introduced: 100%
- Total coverage impact: statements 87.69% → 87.90%, lines 87.46% → 87.86%; 271 → 282 tests, all passing
- Verified end to end against the real `antigravity-acp` agent: an approved command ran and its reply reached the workspace; an unanswered one timed out, the cancellation reached the agent (`Antigravity SDK prompt cancelled`), the call was answered `cancelled`, and the workspace was told the turn had been cut short

**Other reports**

Cancelling as well as answering is deliberate. The spec treats `cancelled` as the answer a client gives *because* it cancelled the turn — answering alone would leave the agent free to carry on and ask again.

TaskID: 0i4iu2Ujkw5

Generated with [AgentRQ](https://agentrq.com)