### PR TITLE
fix: survive a reconnect with approvals in flight

### DIFF
--- a/src/__tests__/acpClient.test.ts
+++ b/src/__tests__/acpClient.test.ts
@@ -1115,6 +1115,48 @@ describe("AgentRQACPClient", () => {
       expect(client.pendingPermissionCount).toBe(0);
     });
 
+    it("should re-send waiting calls when the workspace reconnects", async () => {
+      const waiting = client.requestPermission(params());
+      await vi.waitFor(() => expect(client.pendingPermissionCount).toBe(1));
+      const sentFirst = mcpBridge.sendNotification.mock.calls.length;
+
+      mcpBridge.emit("reconnected");
+      await vi.waitFor(() =>
+        expect(mcpBridge.sendNotification.mock.calls.length).toBe(sentFirst + 1),
+      );
+
+      // Same request id: the workspace has to recognise this as the decision it
+      // is already showing, not a new one to ask about again.
+      const [first, resent] = mcpBridge.sendNotification.mock.calls.map((c: any[]) => c[1]);
+      expect(resent).toEqual(first);
+      expect(client.pendingPermissionCount).toBe(1);
+
+      answerWith("allow");
+      expect((await waiting).outcome.outcome).toBe("selected");
+    });
+
+    it("should not talk to the workspace on reconnect when nothing is waiting", () => {
+      mcpBridge.emit("reconnected");
+
+      expect(mcpBridge.sendNotification).not.toHaveBeenCalled();
+    });
+
+    it("should keep waiting when the re-send itself fails", async () => {
+      const waiting = client.requestPermission(params());
+      await vi.waitFor(() => expect(client.pendingPermissionCount).toBe(1));
+
+      mcpBridge.sendNotification.mockRejectedValueOnce(new Error("still down"));
+      mcpBridge.emit("reconnected");
+      await vi.waitFor(() =>
+        expect(mcpBridge.sendNotification.mock.calls.length).toBeGreaterThan(1),
+      );
+
+      // The next reconnect gets another go; giving up here would lose the turn.
+      expect(client.pendingPermissionCount).toBe(1);
+      client.cancelPendingPermissions("test over");
+      await waiting;
+    });
+
     it("should say nothing when there is nothing waiting to cancel", () => {
       const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       client.cancelPendingPermissions("nothing doing");

--- a/src/__tests__/mcpClient.test.ts
+++ b/src/__tests__/mcpClient.test.ts
@@ -260,4 +260,20 @@ describe("MCPBridge", () => {
       });
     });
   });
+  it("should announce a reconnection, but not a first connection", async () => {
+    const bridge = new MCPBridge(config);
+    const reconnected = vi.fn();
+    bridge.on("reconnected", reconnected);
+
+    await bridge.connect();
+    expect(reconnected).not.toHaveBeenCalled();
+
+    // Losing the connection orphans every permission request in flight, since
+    // the workspace routes each verdict to the session it arrived on.
+    lastMockTransport.onclose();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(reconnected).toHaveBeenCalledTimes(1);
+  });
+
 });

--- a/src/acpClient.ts
+++ b/src/acpClient.ts
@@ -70,6 +70,7 @@ export class AgentRQACPClient implements acp.Client {
   ) {
     this.permissionTimeoutMs = options.permissionTimeoutMs ?? DEFAULT_PERMISSION_TIMEOUT_MS;
     this.mcpBridge.on("verdict", this.onVerdict);
+    this.mcpBridge.on("reconnected", this.onWorkspaceReconnected);
   }
 
   /** How many tool calls are waiting on a human right now. */
@@ -100,6 +101,33 @@ export class AgentRQACPClient implements acp.Client {
       pending.settle({ outcome: "cancelled" });
     }
   }
+
+  /**
+   * Re-sends everything still waiting, after the workspace connection was
+   * re-established on a new session.
+   *
+   * A verdict is routed back to the session its request arrived on, so a
+   * request that was in flight across a reconnect can never be answered. The
+   * request id stays the same, which is what lets the workspace recognise this
+   * as the same pending decision rather than a new one to ask about again.
+   */
+  private onWorkspaceReconnected = (): void => {
+    if (this.pendingPermissions.size === 0) return;
+    console.error(
+      `[acp] Workspace reconnected — re-sending ${this.pendingPermissions.size} ` +
+        `permission request(s) that would otherwise never be answered`,
+    );
+    for (const pending of this.pendingPermissions.values()) {
+      void this.mcpBridge
+        .sendNotification("notifications/claude/channel/permission_request", pending.payload)
+        .catch((err) => {
+          console.error(
+            `[acp] Failed to re-send permission request ${pending.payload.request_id}:`,
+            err,
+          );
+        });
+    }
+  };
 
   /** Delivers a verdict to whichever tool call is waiting on it, if any. */
   private onVerdict = (data: { requestId: string; behavior: string }): void => {

--- a/src/mcpClient.ts
+++ b/src/mcpClient.ts
@@ -17,6 +17,9 @@ export class MCPBridge extends EventEmitter {
   private isConnected = false;
   private isConnecting = false;
   private isClosed = false;
+  // Whether this bridge has ever been connected. A second connection is a
+  // reconnection, which matters to anything already waiting on the workspace.
+  private hasConnected = false;
 
   public getSessionId(): string | undefined {
     return (this.transport as any)?._sessionId;
@@ -43,6 +46,14 @@ export class MCPBridge extends EventEmitter {
         await this._connectOnce();
         this.isConnected = true;
         console.error(`[mcp] Connected to ${this.config.name}`);
+        if (this.hasConnected) {
+          // agentrq routes a permission verdict to the MCP session its request
+          // arrived on, and reconnecting mints a new one — so anything already
+          // waiting for an answer has just been orphaned. Say so, rather than
+          // let those calls sit until they time out.
+          this.emit("reconnected");
+        }
+        this.hasConnected = true;
       } catch (error: any) {
         if (this.isClosed) break;
         const delay = Math.min(initialDelay * Math.pow(2, attempt), maxDelay);


### PR DESCRIPTION
Stacked on #39.

**What changed**

When the connection to the workspace is re-established, every approval still waiting is sent again under the same identity, so it can still be answered.

**Why changed**

The workspace sends each approval decision back to the specific connection the request came in on, and reconnecting creates a new one. Anything waiting when the connection dropped was therefore unanswerable — an ordinary network blip quietly cost the whole turn, with the decision discarded on the server side and the agent left waiting until it timed out.

**Test coverage report**

- New lines introduced: 100%
- Total coverage impact: statements 87.90% → 88.05%, lines 87.86% → 88.01%; 282 → 286 tests, all passing
- Verified end to end against the real `antigravity-acp` agent: with an approval outstanding, the workspace connection was dropped; the gateway reconnected, re-sent the request under its original id, and the approval that followed reached the agent and ran the command. Before this change that decision went to a dead connection

**Other reports**

Pairs with a workspace-side change that treats a repeat of a known request id as the same decision moving to a new connection, rather than posting a second approval card. Until that lands, a reconnect shows the request twice.

TaskID: 0i4iuRqiJHN

Generated with [AgentRQ](https://agentrq.com)