### PR TITLE
fix: notice when the agent stops asking before it acts

### DIFF
--- a/src/__tests__/acpClient.test.ts
+++ b/src/__tests__/acpClient.test.ts
@@ -1166,6 +1166,29 @@ describe("AgentRQACPClient", () => {
     });
   });
 
+  describe("session mode changes", () => {
+    it("should hand a mode change to whoever is watching for it", async () => {
+      const onMode = vi.fn();
+      client.setModeChangeHandler(onMode);
+
+      await client.sessionUpdate({
+        sessionId: "sess-1",
+        update: { sessionUpdate: "current_mode_update", currentModeId: "auto" },
+      } as any);
+
+      expect(onMode).toHaveBeenCalledWith("sess-1", "auto");
+    });
+
+    it("should not mind a mode change nobody is watching for", async () => {
+      await expect(
+        client.sessionUpdate({
+          sessionId: "sess-1",
+          update: { sessionUpdate: "current_mode_update", currentModeId: "auto" },
+        } as any),
+      ).resolves.toBeUndefined();
+    });
+  });
+
   describe("reportStopReason", () => {
     function clientForTask(taskId: string | undefined) {
       return new AgentRQACPClient(mcpBridge as unknown as MCPBridge, () => taskId);

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Writable, Readable } from "node:stream";
 import { EventEmitter } from "node:events";
 import * as acp from "@agentclientprotocol/sdk";
@@ -22,6 +22,7 @@ import {
   runListAgents,
   pickHumanApprovalMode,
   enforceHumanApprovalMode,
+  handleAgentModeChange,
   runAgentCommand,
 } from "../index.js";
 import { AUTH_REQUIRED_CODE } from "../auth.js";
@@ -1200,4 +1201,83 @@ describe("index", () => {
       );
     });
   });
+  describe("handleAgentModeChange", () => {
+    const modes: any = {
+      currentModeId: "ask",
+      availableModes: [
+        { id: "ask", name: "Ask first" },
+        { id: "auto", name: "Auto approve" },
+      ],
+    };
+
+    let errorSpy: any;
+    beforeEach(() => {
+      errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+    afterEach(() => errorSpy.mockRestore());
+
+    it("should leave a mode that still asks the human alone", async () => {
+      const connection: any = { setSessionMode: vi.fn() };
+
+      await handleAgentModeChange(connection, "sess-ok", "ask", modes);
+
+      expect(connection.setSessionMode).not.toHaveBeenCalled();
+    });
+
+    it("should put the session back when the agent starts approving for us", async () => {
+      const connection: any = { setSessionMode: vi.fn().mockResolvedValue({}) };
+
+      await handleAgentModeChange(connection, "sess-drift", "auto", modes);
+
+      expect(connection.setSessionMode).toHaveBeenCalledWith({
+        sessionId: "sess-drift",
+        modeId: "ask",
+      });
+    });
+
+    it("should treat a mode the agent never advertised as untrusted", async () => {
+      const connection: any = { setSessionMode: vi.fn().mockResolvedValue({}) };
+
+      await handleAgentModeChange(connection, "sess-unknown", "something-new", modes);
+
+      expect(connection.setSessionMode).toHaveBeenCalledWith({
+        sessionId: "sess-unknown",
+        modeId: "ask",
+      });
+    });
+
+    it("should stop fighting an agent that keeps switching back", async () => {
+      const connection: any = { setSessionMode: vi.fn().mockResolvedValue({}) };
+
+      for (let i = 0; i < 5; i++) {
+        await handleAgentModeChange(connection, "sess-stubborn", "auto", modes);
+      }
+
+      // An unbounded fight would be an endless stream of setSessionMode calls.
+      expect(connection.setSessionMode).toHaveBeenCalledTimes(3);
+      expect(errorSpy.mock.calls.flat().join("\n")).toContain("Giving up after 3 attempts");
+    });
+
+    it("should start counting again once the session is back in a safe mode", async () => {
+      const connection: any = { setSessionMode: vi.fn().mockResolvedValue({}) };
+
+      await handleAgentModeChange(connection, "sess-recovered", "auto", modes);
+      await handleAgentModeChange(connection, "sess-recovered", "ask", modes);
+      for (let i = 0; i < 4; i++) {
+        await handleAgentModeChange(connection, "sess-recovered", "auto", modes);
+      }
+
+      expect(connection.setSessionMode).toHaveBeenCalledTimes(4);
+    });
+
+    it("should do nothing for an agent that offers no modes at all", async () => {
+      const connection: any = { setSessionMode: vi.fn() };
+
+      await handleAgentModeChange(connection, "sess-modeless", "whatever", undefined);
+      await handleAgentModeChange(connection, "sess-modeless", "whatever", { availableModes: [] } as any);
+
+      expect(connection.setSessionMode).not.toHaveBeenCalled();
+    });
+  });
+
 });

--- a/src/acpClient.ts
+++ b/src/acpClient.ts
@@ -62,6 +62,7 @@ export class AgentRQACPClient implements acp.Client {
   private pendingPermissions = new Map<string, PendingPermission>();
   private permissionTimeoutMs: number;
   private cancelSession?: (sessionId: string) => unknown;
+  private onModeChanged?: (sessionId: string, modeId: string) => unknown;
 
   constructor(
     private mcpBridge: MCPBridge,
@@ -71,6 +72,17 @@ export class AgentRQACPClient implements acp.Client {
     this.permissionTimeoutMs = options.permissionTimeoutMs ?? DEFAULT_PERMISSION_TIMEOUT_MS;
     this.mcpBridge.on("verdict", this.onVerdict);
     this.mcpBridge.on("reconnected", this.onWorkspaceReconnected);
+  }
+
+  /**
+   * Supplies what to do when the agent changes its own session mode.
+   *
+   * The gateway pins a mode that routes approvals to the human at session
+   * creation, but agents may switch modes on their own — and back into one
+   * that approves on the user's behalf.
+   */
+  setModeChangeHandler(handler: (sessionId: string, modeId: string) => unknown): void {
+    this.onModeChanged = handler;
   }
 
   /** How many tool calls are waiting on a human right now. */
@@ -396,6 +408,10 @@ export class AgentRQACPClient implements acp.Client {
           const sid = params.sessionId;
           this.replyBuffers.set(sid, (this.replyBuffers.get(sid) ?? "") + update.content.text);
         }
+        break;
+      case "current_mode_update":
+        console.error(`[acp] Agent switched session mode to "${update.currentModeId}"`);
+        await this.onModeChanged?.(params.sessionId, update.currentModeId);
         break;
       case "tool_call_update":
         this.rememberToolCall(update);

--- a/src/index.ts
+++ b/src/index.ts
@@ -306,6 +306,11 @@ export async function getOrCreateSession(
   console.error(`[acp] Created session ${sessionResult.sessionId} for task ${key}`);
 
   await enforceHumanApprovalMode(connection, sessionResult);
+  // The mode is pinned once here, but agents may move themselves back out of
+  // it, so keep watching for the rest of the session's life.
+  acpClient.setModeChangeHandler((changedSessionId, modeId) =>
+    handleAgentModeChange(connection, changedSessionId, modeId, sessionResult.modes),
+  );
 
   const sessionInfo: AgentSession = {
     process: agentProcess,
@@ -392,6 +397,64 @@ export async function enforceHumanApprovalMode(
       err,
     );
   }
+}
+
+/**
+ * How many times the gateway will drag one session back into a mode that asks
+ * the human. An agent that keeps switching back is not going to stop, and an
+ * unbounded fight with it would be an endless stream of setSessionMode calls.
+ */
+const MAX_MODE_REENFORCEMENTS = 3;
+
+/** sessionId → how many times its mode has already been put back. */
+const modeReenforcements = new Map<string, number>();
+
+/**
+ * Puts a session back into a mode that asks the human, after the agent moved
+ * itself out of one.
+ *
+ * Agents may change modes on their own. If one moves into a mode that approves
+ * tool calls on the user's behalf, every later tool call — including
+ * destructive ones — executes without ever reaching agentrq, and nothing
+ * anywhere says so.
+ */
+export async function handleAgentModeChange(
+  connection: acp.ClientSideConnection,
+  sessionId: string,
+  currentModeId: string,
+  modes: acp.SessionModeState | null | undefined,
+): Promise<void> {
+  const available = modes?.availableModes;
+  if (!available?.length) return;
+
+  const mode = available.find((m) => m.id === currentModeId);
+  // A mode the agent never advertised cannot be vouched for either, so it is
+  // treated the same as one that approves on our behalf.
+  if (mode && !AUTO_APPROVING_MODE.test(describeMode(mode))) {
+    modeReenforcements.delete(sessionId);
+    return;
+  }
+
+  const attempts = modeReenforcements.get(sessionId) ?? 0;
+  if (attempts >= MAX_MODE_REENFORCEMENTS) {
+    console.error(
+      `[acp] ⚠️  Agent keeps returning session ${sessionId} to mode "${currentModeId}", ` +
+        `which approves tool calls without asking. Giving up after ` +
+        `${MAX_MODE_REENFORCEMENTS} attempts — tool calls may now execute without ` +
+        `agentrq approval.`,
+    );
+    return;
+  }
+  modeReenforcements.set(sessionId, attempts + 1);
+
+  console.error(
+    `[acp] ⚠️  Agent moved session ${sessionId} into "${currentModeId}", which approves ` +
+      `tool calls without asking. Putting it back.`,
+  );
+  await enforceHumanApprovalMode(connection, {
+    sessionId,
+    modes: { availableModes: available, currentModeId },
+  });
 }
 
 export function createAcpSessionSwitcher(


### PR DESCRIPTION
Stacked on #40.

**What changed**

The session mode that sends every tool-call approval to the human is now watched for the life of the session, and put back if the agent moves itself out of it.

**Why changed**

That mode was set once, when the session started, and never checked again — while the protocol explicitly allows agents to change modes on their own. An agent that switched back into a mode which approves on the user's behalf would silently stop asking, and every tool call after that, including destructive ones, would run with nobody consulted and nothing anywhere reporting it.

A mode the agent never advertised is treated as untrusted for the same reason: it cannot be vouched for. An agent that keeps switching back is given up on after three attempts with a loud warning, rather than fought with in an endless exchange.

**Test coverage report**

- New lines introduced: 100%
- Total coverage impact: statements 88.05% → 88.24%, lines 88.01% → 88.18%; 286 → 294 tests, all passing
- Unit-tested only, deliberately: this is the one change in the stack with no end-to-end proof, because it needs an agent that switches its own mode on demand and none of the available ones will. The wiring it hangs off — the session-update path and `enforceHumanApprovalMode` — is exercised live by the rest of the stack

TaskID: 0i4ivNRa7az

Generated with [AgentRQ](https://agentrq.com)