### PR TITLE
feat: show the human the diff they are approving

### DIFF
--- a/src/__tests__/acpClient.test.ts
+++ b/src/__tests__/acpClient.test.ts
@@ -1027,6 +1027,63 @@ describe("AgentRQACPClient", () => {
       expect(mcpBridge.sendNotification.mock.calls[0][1].request_id).toBe("call-1");
     });
 
+    it("should send the human the diff, kind and files, not just the raw input", async () => {
+      answerWith("allow");
+      await client.requestPermission(
+        params({
+          toolCall: {
+            toolCallId: "call-edit",
+            title: "Edit config.ts",
+            kind: "edit",
+            rawInput: { path: "config.ts" },
+            locations: [{ path: "/repo/config.ts", line: 12 }],
+            content: [
+              { type: "diff", path: "/repo/config.ts", oldText: "port = 80", newText: "port = 443" },
+            ],
+          },
+        }),
+      );
+
+      const sent = mcpBridge.sendNotification.mock.calls[0][1];
+      expect(sent.tool_kind).toBe("edit");
+      expect(sent.locations).toEqual(["/repo/config.ts:12"]);
+      expect(sent.content_preview).toContain("-port = 80");
+      expect(sent.content_preview).toContain("+port = 443");
+      // Unchanged: agentrq parses this as JSON to match auto-allow rules.
+      expect(sent.input_preview).toBe(JSON.stringify({ path: "config.ts" }));
+    });
+
+    it("should take the diff from the earlier tool call when the request omits it", async () => {
+      await client.sessionUpdate({
+        sessionId: "sess-1",
+        update: {
+          sessionUpdate: "tool_call",
+          toolCallId: "call-1",
+          title: "Edit",
+          kind: "edit",
+          status: "pending",
+          content: [{ type: "diff", path: "/repo/a.ts", oldText: "a", newText: "b" }],
+        },
+      } as any);
+
+      answerWith("allow");
+      await client.requestPermission(params({ toolCall: { toolCallId: "call-1", title: "Edit" } }));
+
+      const sent = mcpBridge.sendNotification.mock.calls[0][1];
+      expect(sent.tool_kind).toBe("edit");
+      expect(sent.content_preview).toContain("+b");
+    });
+
+    it("should send nothing extra for a call that describes nothing extra", async () => {
+      answerWith("allow");
+      await client.requestPermission(params());
+
+      const sent = mcpBridge.sendNotification.mock.calls[0][1];
+      expect(sent).not.toHaveProperty("tool_kind");
+      expect(sent).not.toHaveProperty("locations");
+      expect(sent).not.toHaveProperty("content_preview");
+    });
+
     it("should keep one verdict listener however many calls are waiting", async () => {
       const waiting = [
         client.requestPermission(params()),

--- a/src/__tests__/toolCallPreview.test.ts
+++ b/src/__tests__/toolCallPreview.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { describeToolCall, renderDiff, MAX_PREVIEW_CHARS } from "../toolCallPreview.js";
+
+describe("renderDiff", () => {
+  it("should show a new file as all additions", () => {
+    const diff = renderDiff("/tmp/new.ts", null, "one\ntwo");
+
+    expect(diff).toContain("--- /dev/null");
+    expect(diff).toContain("+++ /tmp/new.ts");
+    expect(diff).toContain("+one");
+    expect(diff).toContain("+two");
+  });
+
+  it("should show only the part of a file that changes", () => {
+    const before = ["a", "b", "c", "d", "e", "f", "g", "h"].join("\n");
+    const after = ["a", "b", "c", "d", "CHANGED", "f", "g", "h"].join("\n");
+
+    const diff = renderDiff("/tmp/f.ts", before, after);
+
+    expect(diff).toContain("-e");
+    expect(diff).toContain("+CHANGED");
+    // Unchanged lines outside the context window stay out of it.
+    expect(diff).not.toContain(" a");
+    expect(diff).toContain(" d");
+  });
+
+  it("should show an insertion with nothing removed", () => {
+    const diff = renderDiff("/tmp/f.ts", "a\nb", "a\nnew\nb");
+
+    expect(diff).toContain("+new");
+    expect(diff.split("\n").filter((l) => l.startsWith("-"))).toHaveLength(1); // the --- header
+  });
+
+  it("should say so when the texts are identical", () => {
+    expect(renderDiff("/tmp/f.ts", "same", "same")).toContain("(no change)");
+  });
+
+  it("should count the changed lines in the hunk header", () => {
+    const diff = renderDiff("/tmp/f.ts", "a\nb\nc", "a\nx\ny\nc");
+
+    expect(diff).toContain("@@ -2,1 +2,2 @@");
+  });
+});
+
+describe("describeToolCall", () => {
+  it("should leave out everything the call did not supply", () => {
+    expect(describeToolCall({})).toEqual({});
+    expect(describeToolCall({ kind: null, locations: null, content: null })).toEqual({});
+    expect(describeToolCall({ locations: [], content: [] })).toEqual({});
+  });
+
+  it("should report the tool's kind and the files it touches", () => {
+    const preview = describeToolCall({
+      kind: "edit",
+      locations: [{ path: "/src/a.ts" }, { path: "/src/b.ts", line: 42 }] as any,
+    });
+
+    expect(preview.kind).toBe("edit");
+    expect(preview.locations).toEqual(["/src/a.ts", "/src/b.ts:42"]);
+  });
+
+  it("should render the diff a human is being asked to approve", () => {
+    const preview = describeToolCall({
+      content: [
+        { type: "diff", path: "/src/a.ts", oldText: "old", newText: "new" },
+      ] as any,
+    });
+
+    expect(preview.contentPreview).toContain("-old");
+    expect(preview.contentPreview).toContain("+new");
+  });
+
+  it("should render text, media and links without dropping them", () => {
+    const preview = describeToolCall({
+      content: [
+        { type: "content", content: { type: "text", text: "about to run" } },
+        { type: "content", content: { type: "image", mimeType: "image/png", data: "x" } },
+        { type: "content", content: { type: "resource_link", uri: "file:///a" } },
+        { type: "content", content: { type: "audio", mimeType: "audio/wav", data: "x" } },
+        { type: "content", content: { type: "resource", resource: { uri: "file:///b" } } },
+        { type: "terminal", terminalId: "term-1" },
+      ] as any,
+    });
+
+    expect(preview.contentPreview).toContain("about to run");
+    expect(preview.contentPreview).toContain("[image image/png]");
+    expect(preview.contentPreview).toContain("[link file:///a]");
+    expect(preview.contentPreview).toContain("[audio audio/wav]");
+    expect(preview.contentPreview).toContain("[resource file:///b]");
+    expect(preview.contentPreview).toContain("[terminal term-1]");
+  });
+
+  it("should skip blocks it has no rendering for", () => {
+    const preview = describeToolCall({
+      content: [
+        { type: "something-new" },
+        { type: "content", content: { type: "unknown-kind" } },
+        { type: "content", content: { type: "text", text: "   " } },
+      ] as any,
+    });
+
+    expect(preview.contentPreview).toBeUndefined();
+  });
+
+  it("should cap a preview so one edit cannot flood the chat", () => {
+    const huge = "x".repeat(MAX_PREVIEW_CHARS * 2);
+    const preview = describeToolCall({
+      content: [{ type: "content", content: { type: "text", text: huge } }] as any,
+    });
+
+    expect(preview.contentPreview!.length).toBeLessThan(MAX_PREVIEW_CHARS + 100);
+    expect(preview.contentPreview).toContain("truncated");
+  });
+});

--- a/src/acpClient.ts
+++ b/src/acpClient.ts
@@ -7,6 +7,7 @@
 
 import * as acp from "@agentclientprotocol/sdk";
 import type { MCPBridge } from "./mcpClient.js";
+import { describeToolCall } from "./toolCallPreview.js";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
@@ -54,7 +55,16 @@ export class AgentRQACPClient implements acp.Client {
   // carries a title, but the permission request for that same call may omit it
   // (ACP marks it optional there, and codex-acp sends it bare), which would
   // otherwise leave us unable to tell an agentrq MCP call from anything else.
-  private toolCallDetails = new Map<string, { title?: string; rawInput?: unknown }>();
+  private toolCallDetails = new Map<
+    string,
+    {
+      title?: string;
+      rawInput?: unknown;
+      kind?: string;
+      locations?: acp.ToolCallLocation[];
+      content?: acp.ToolCallContent[];
+    }
+  >();
 
   // request_id → the tool call waiting on a human. One shared verdict listener
   // serves them all: a listener per request was only ever removed on a matching
@@ -224,6 +234,13 @@ export class AgentRQACPClient implements acp.Client {
     this.toolCallDetails.delete(toolCallId);
     const toolTitle = params.toolCall.title ?? remembered?.title ?? "Unknown Tool";
     const rawInput = params.toolCall.rawInput ?? remembered?.rawInput;
+    // The diff and the file list are usually on the earlier tool_call update
+    // rather than the permission request, so fall back to that the same way.
+    const preview = describeToolCall({
+      kind: params.toolCall.kind ?? remembered?.kind,
+      locations: params.toolCall.locations ?? remembered?.locations,
+      content: params.toolCall.content ?? remembered?.content,
+    });
 
     // Auto-allow tool calls that contain the pattern: agentrq-<11 chars a-zA-Z0-9>
     if (AGENTRQ_TOOL_PATTERN.test(toolTitle)) {
@@ -257,7 +274,12 @@ export class AgentRQACPClient implements acp.Client {
       task_id: taskId,
       tool_name: toolTitle,
       description: toolTitle,
+      // input_preview stays exactly as it was: agentrq parses it as JSON to
+      // match saved auto-allow rules. Everything new travels alongside it.
       input_preview: JSON.stringify(rawInput ?? {}),
+      ...(preview.kind ? { tool_kind: preview.kind } : {}),
+      ...(preview.locations ? { locations: preview.locations } : {}),
+      ...(preview.contentPreview ? { content_preview: preview.contentPreview } : {}),
     };
     console.error(`[acp] Bridge Session ID: ${this.mcpBridge.getSessionId() ?? "unknown"}`);
     console.error(`[acp] Sending permission request notification:`, JSON.stringify(payload, null, 2));
@@ -380,6 +402,9 @@ export class AgentRQACPClient implements acp.Client {
     title?: string | null;
     rawInput?: unknown;
     status?: string | null;
+    kind?: string | null;
+    locations?: acp.ToolCallLocation[] | null;
+    content?: acp.ToolCallContent[] | null;
   }): void {
     const id = update.toolCallId;
     if (!id) return;
@@ -392,10 +417,15 @@ export class AgentRQACPClient implements acp.Client {
     }
 
     const previous = this.toolCallDetails.get(id);
-    const title = update.title ?? previous?.title;
-    const rawInput = update.rawInput ?? previous?.rawInput;
-    if (title === undefined && rawInput === undefined) return;
-    this.toolCallDetails.set(id, { title, rawInput });
+    const details = {
+      title: update.title ?? previous?.title,
+      rawInput: update.rawInput ?? previous?.rawInput,
+      kind: update.kind ?? previous?.kind,
+      locations: update.locations ?? previous?.locations,
+      content: update.content ?? previous?.content,
+    };
+    if (Object.values(details).every((value) => value === undefined)) return;
+    this.toolCallDetails.set(id, details);
   }
 
   async sessionUpdate(params: acp.SessionNotification): Promise<void> {

--- a/src/toolCallPreview.ts
+++ b/src/toolCallPreview.ts
@@ -1,0 +1,147 @@
+/**
+ * toolCallPreview.ts
+ *
+ * Renders what a tool call is about to do, for the human being asked to
+ * approve it.
+ *
+ * ACP already tells the client this — a permission request carries the tool's
+ * kind, the files it touches, and its content, including diffs of the exact
+ * edits. Forwarding only the raw input meant people were approving file edits
+ * without being shown the change.
+ */
+
+import * as acp from "@agentclientprotocol/sdk";
+
+/**
+ * How much of a preview to send. A permission card is something to read at a
+ * glance, and the whole payload travels through a chat message.
+ */
+export const MAX_PREVIEW_CHARS = 4000;
+
+/** Lines of unchanged context kept either side of a change. */
+const CONTEXT_LINES = 3;
+
+function truncate(text: string): string {
+  if (text.length <= MAX_PREVIEW_CHARS) return text;
+  return `${text.slice(0, MAX_PREVIEW_CHARS)}\n… truncated, ${text.length - MAX_PREVIEW_CHARS} more characters`;
+}
+
+/**
+ * Renders an edit as a diff.
+ *
+ * The changed region is found by trimming the common prefix and suffix rather
+ * than by a full longest-common-subsequence pass: it is a fraction of the code,
+ * costs nothing on large files, and gives the same answer for the single-region
+ * edits that make up nearly every tool call. Several scattered edits in one file
+ * collapse into a single wider block — less tight, never wrong.
+ */
+export function renderDiff(path: string, oldText: string | null | undefined, newText: string): string {
+  if (oldText == null) {
+    const lines = newText.split("\n");
+    return [`--- /dev/null`, `+++ ${path}`, ...lines.map((l) => `+${l}`)].join("\n");
+  }
+
+  const before = oldText.split("\n");
+  const after = newText.split("\n");
+
+  let start = 0;
+  while (start < before.length && start < after.length && before[start] === after[start]) {
+    start++;
+  }
+  let end = 0;
+  while (
+    end < before.length - start &&
+    end < after.length - start &&
+    before[before.length - 1 - end] === after[after.length - 1 - end]
+  ) {
+    end++;
+  }
+
+  if (start === before.length && before.length === after.length) {
+    return `--- ${path}\n+++ ${path}\n(no change)`;
+  }
+
+  const contextStart = Math.max(0, start - CONTEXT_LINES);
+  const removed = before.slice(start, before.length - end);
+  const added = after.slice(start, after.length - end);
+  const leading = before.slice(contextStart, start);
+  const trailing = before.slice(before.length - end, before.length - end + CONTEXT_LINES);
+
+  return [
+    `--- ${path}`,
+    `+++ ${path}`,
+    `@@ -${start + 1},${removed.length} +${start + 1},${added.length} @@`,
+    ...leading.map((l) => ` ${l}`),
+    ...removed.map((l) => `-${l}`),
+    ...added.map((l) => `+${l}`),
+    ...trailing.map((l) => ` ${l}`),
+  ].join("\n");
+}
+
+/** Renders one ACP content block as something readable in a chat message. */
+function renderBlock(block: acp.ToolCallContent): string | undefined {
+  switch (block.type) {
+    case "diff":
+      return renderDiff(block.path, block.oldText, block.newText);
+    case "terminal":
+      return `[terminal ${block.terminalId}]`;
+    case "content":
+      return renderContentBlock(block.content);
+    default:
+      return undefined;
+  }
+}
+
+function renderContentBlock(content: acp.ContentBlock | undefined): string | undefined {
+  if (!content) return undefined;
+  switch (content.type) {
+    case "text":
+      return content.text;
+    case "image":
+      return `[image${content.mimeType ? ` ${content.mimeType}` : ""}]`;
+    case "audio":
+      return `[audio${content.mimeType ? ` ${content.mimeType}` : ""}]`;
+    case "resource_link":
+      return `[link ${content.uri}]`;
+    case "resource":
+      return `[resource ${(content.resource as { uri?: string })?.uri ?? ""}]`.trim();
+    default:
+      return undefined;
+  }
+}
+
+/** What a permission card should show beyond the tool's name and raw input. */
+export interface ToolCallPreview {
+  /** ACP's category for the tool: read, edit, delete, execute, … */
+  kind?: string;
+  /** The files the call says it will touch. */
+  locations?: string[];
+  /** Diffs and output, rendered for reading. */
+  contentPreview?: string;
+}
+
+/**
+ * Pulls out everything about a tool call worth showing a human, leaving out
+ * whatever the call did not supply.
+ */
+export function describeToolCall(toolCall: {
+  kind?: string | null;
+  locations?: acp.ToolCallLocation[] | null;
+  content?: acp.ToolCallContent[] | null;
+}): ToolCallPreview {
+  const preview: ToolCallPreview = {};
+
+  if (toolCall.kind) preview.kind = toolCall.kind;
+
+  const locations = toolCall.locations
+    ?.map((l) => (l.line ? `${l.path}:${l.line}` : l.path))
+    .filter(Boolean);
+  if (locations?.length) preview.locations = locations;
+
+  const rendered = toolCall.content
+    ?.map(renderBlock)
+    .filter((block): block is string => Boolean(block && block.trim()));
+  if (rendered?.length) preview.contentPreview = truncate(rendered.join("\n\n"));
+
+  return preview;
+}


### PR DESCRIPTION
Stacked on #41.

**What changed**

An approval request now carries what the tool is about to do — the kind of operation, the files it touches, and a readable diff of the exact edit — alongside the raw input it carried before.

**Why changed**

The protocol already describes all of this to the gateway, and the gateway was throwing it away. Someone approving a file edit saw the tool's name and a blob of raw input, which for a whole-file write is the new contents with no indication of what actually changed. The one thing they most need in order to decide was the one thing not being shown.

**Test coverage report**

- New lines introduced: 100%
- Total coverage impact: statements 88.24% → 88.79%, lines 88.18% → 88.80%; 294 → 308 tests, all passing
- Verified end to end against the real `antigravity-acp` agent, asked to change a port in a config file. The request arrived with kind `edit`, the file path, and the diff below — where previously only the raw input was forwarded:

```
--- .e2e/run/config.toml
+++ .e2e/run/config.toml
@@ -1,1 +1,1 @@
-port = 80
+port = 443
 host = "localhost"
 debug = false
```

**Other reports**

Safe to merge before the workspace-side rendering: the existing input field is untouched, because auto-allow rules are matched by parsing it, and the workspace ignores fields it does not know. Until the rendering lands, the new fields are carried but not displayed.

TaskID: 0i4ivosQYzZ

Generated with [AgentRQ](https://agentrq.com)