### PR TITLE
feat: recover a conversation across a gateway restart

### DIFF
--- a/src/__tests__/acpClient.test.ts
+++ b/src/__tests__/acpClient.test.ts
@@ -1246,6 +1246,76 @@ describe("AgentRQACPClient", () => {
     });
   });
 
+  describe("withRepliesSuppressed", () => {
+    function clientForTask(taskId: string) {
+      return new AgentRQACPClient(mcpBridge as unknown as MCPBridge, () => taskId);
+    }
+
+    const chunk = (sessionId: string, text: string) => ({
+      sessionId,
+      update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text } },
+    }) as any;
+
+    it("should drop a replayed conversation instead of re-posting it", async () => {
+      const client = clientForTask("task-1");
+
+      await client.withRepliesSuppressed("sess-1", async () => {
+        await client.sessionUpdate(chunk("sess-1", "everything said before"));
+      });
+      await client.flushReply("sess-1");
+
+      // session/load replays the whole conversation as ordinary chunks.
+      expect(mcpBridge.callTool).not.toHaveBeenCalled();
+    });
+
+    it("should keep buffering once the replay is over", async () => {
+      const client = clientForTask("task-1");
+
+      await client.withRepliesSuppressed("sess-1", async () => {
+        await client.sessionUpdate(chunk("sess-1", "old news"));
+      });
+      await client.sessionUpdate(chunk("sess-1", "something new"));
+      await client.flushReply("sess-1");
+
+      expect(mcpBridge.callTool).toHaveBeenCalledWith("reply", {
+        chatId: "task-1",
+        text: "something new",
+      });
+    });
+
+    it("should keep buffering other sessions during a replay", async () => {
+      const client = clientForTask("task-1");
+
+      await client.withRepliesSuppressed("sess-1", async () => {
+        await client.sessionUpdate(chunk("sess-2", "unrelated"));
+      });
+      await client.flushReply("sess-2");
+
+      expect(mcpBridge.callTool).toHaveBeenCalledWith("reply", {
+        chatId: "task-1",
+        text: "unrelated",
+      });
+    });
+
+    it("should stop suppressing even when the load fails", async () => {
+      const client = clientForTask("task-1");
+
+      await expect(
+        client.withRepliesSuppressed("sess-1", async () => {
+          throw new Error("load failed");
+        }),
+      ).rejects.toThrow("load failed");
+
+      await client.sessionUpdate(chunk("sess-1", "after the failure"));
+      await client.flushReply("sess-1");
+
+      expect(mcpBridge.callTool).toHaveBeenCalledWith("reply", {
+        chatId: "task-1",
+        text: "after the failure",
+      });
+    });
+  });
+
   describe("reportStopReason", () => {
     function clientForTask(taskId: string | undefined) {
       return new AgentRQACPClient(mcpBridge as unknown as MCPBridge, () => taskId);

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -22,6 +22,7 @@ import {
   pickHumanApprovalMode,
   enforceHumanApprovalMode,
   shutdownAgent,
+  sessionRecovery,
   handleAgentModeChange,
   runAgentCommand,
 } from "../index.js";
@@ -77,6 +78,7 @@ describe("index", () => {
     shutdownAgent();
     activeSessions.clear();
     spawnedAgents.length = 0;
+    sessionRecovery.store = undefined;
   });
 
   describe("mapMcpServers", () => {
@@ -1232,6 +1234,177 @@ describe("index", () => {
       await handleAgentModeChange(connection, "sess-modeless", "whatever", { availableModes: [] } as any);
 
       expect(connection.setSessionMode).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("recovering a session across a restart", () => {
+    /** A store that already remembers one task, as a previous run would leave. */
+    function storeRemembering(taskId: string, sessionId: string) {
+      const sessions: Record<string, string> = { [taskId]: sessionId };
+      const store = {
+        get: (id: string) => sessions[id],
+        set: vi.fn((id: string, sid: string) => {
+          sessions[id] = sid;
+        }),
+        delete: vi.fn((id: string) => {
+          delete sessions[id];
+        }),
+      };
+      sessionRecovery.store = store as any;
+      return store;
+    }
+
+    function agentThat(overrides: Record<string, any>, capabilities: Record<string, any>) {
+      const connection: Record<string, any> = {
+        initialize: vi.fn().mockResolvedValue({
+          protocolVersion: 1,
+          agentCapabilities: capabilities,
+        }),
+        newSession: vi.fn().mockResolvedValue({ sessionId: "brand-new" }),
+        setSessionMode: vi.fn().mockResolvedValue({}),
+        prompt: vi.fn(),
+        ...overrides,
+      };
+      vi.mocked(acp.ClientSideConnection).mockImplementationOnce(function () {
+        return connection as any;
+      } as any);
+      return connection;
+    }
+
+    beforeEach(() => {
+      vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    it("should resume the session the task was using before", async () => {
+      const store = storeRemembering("T-Old", "sess-old");
+      const connection = agentThat(
+        { resumeSession: vi.fn().mockResolvedValue({ modes: null }) },
+        { sessionCapabilities: { resume: {} } },
+      );
+
+      const session = await getOrCreateSession("T-Old", ["node", "a.js"], [], { env: {} } as any, fakeBridge());
+
+      expect(connection.resumeSession).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionId: "sess-old" }),
+      );
+      expect(connection.newSession).not.toHaveBeenCalled();
+      expect(session.sessionId).toBe("sess-old");
+      expect(store.delete).not.toHaveBeenCalled();
+    });
+
+    it("should load the session when the agent cannot resume", async () => {
+      storeRemembering("T-Old", "sess-old");
+      const connection = agentThat(
+        { loadSession: vi.fn().mockResolvedValue({ modes: null }) },
+        { loadSession: true },
+      );
+
+      const session = await getOrCreateSession("T-Old", ["node", "a.js"], [], { env: {} } as any, fakeBridge());
+
+      expect(connection.loadSession).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionId: "sess-old" }),
+      );
+      expect(session.sessionId).toBe("sess-old");
+    });
+
+    it("should fall back to loading when resuming fails", async () => {
+      storeRemembering("T-Old", "sess-old");
+      const connection = agentThat(
+        {
+          resumeSession: vi.fn().mockRejectedValue(new Error("gone")),
+          loadSession: vi.fn().mockResolvedValue({ modes: null }),
+        },
+        { sessionCapabilities: { resume: {} }, loadSession: true },
+      );
+
+      const session = await getOrCreateSession("T-Old", ["node", "a.js"], [], { env: {} } as any, fakeBridge());
+
+      expect(connection.loadSession).toHaveBeenCalled();
+      expect(session.sessionId).toBe("sess-old");
+    });
+
+    it("should start fresh, and forget, when the session cannot be recovered", async () => {
+      const store = storeRemembering("T-Old", "sess-old");
+      const connection = agentThat(
+        {
+          resumeSession: vi.fn().mockRejectedValue(new Error("gone")),
+          loadSession: vi.fn().mockRejectedValue(new Error("also gone")),
+        },
+        { sessionCapabilities: { resume: {} }, loadSession: true },
+      );
+
+      const session = await getOrCreateSession("T-Old", ["node", "a.js"], [], { env: {} } as any, fakeBridge());
+
+      expect(connection.newSession).toHaveBeenCalled();
+      expect(session.sessionId).toBe("brand-new");
+      expect(store.delete).toHaveBeenCalledWith("T-Old");
+      expect(store.set).toHaveBeenCalledWith("T-Old", "brand-new");
+    });
+
+    it("should not offer a remembered session to an agent that takes neither back", async () => {
+      storeRemembering("T-Old", "sess-old");
+      const connection = agentThat({ resumeSession: vi.fn(), loadSession: vi.fn() }, {});
+
+      await getOrCreateSession("T-Old", ["node", "a.js"], [], { env: {} } as any, fakeBridge());
+
+      expect(connection.resumeSession).not.toHaveBeenCalled();
+      expect(connection.loadSession).not.toHaveBeenCalled();
+      expect(connection.newSession).toHaveBeenCalled();
+    });
+
+    it("should put a recovered session back into a mode that asks the human", async () => {
+      storeRemembering("T-Old", "sess-old");
+      // Resuming can hand back the agent's own default, which often approves
+      // on the user's behalf.
+      const connection = agentThat(
+        {
+          resumeSession: vi.fn().mockResolvedValue({
+            modes: {
+              currentModeId: "auto",
+              availableModes: [
+                { id: "auto", name: "Auto approve" },
+                { id: "ask", name: "Ask first" },
+              ],
+            },
+          }),
+        },
+        { sessionCapabilities: { resume: {} } },
+      );
+
+      await getOrCreateSession("T-Old", ["node", "a.js"], [], { env: {} } as any, fakeBridge());
+
+      expect(connection.setSessionMode).toHaveBeenCalledWith({
+        sessionId: "sess-old",
+        modeId: "ask",
+      });
+    });
+
+    it("should not treat a task-less session as a task called default", async () => {
+      const store = { get: vi.fn(), set: vi.fn(), delete: vi.fn() };
+      sessionRecovery.store = store as any;
+      agentThat({}, {});
+
+      // getTask can hand back a task whose id could not be read. Its replies
+      // have nowhere to go — they must not go to a chat named "default".
+      await getOrCreateSession(undefined, ["node", "a.js"], [], { env: {} } as any, fakeBridge());
+
+      expect(store.get).not.toHaveBeenCalled();
+      expect(store.set).not.toHaveBeenCalled();
+    });
+
+    it("should remember a brand-new session for next time", async () => {
+      const sessions: Record<string, string> = {};
+      const store = {
+        get: (id: string) => sessions[id],
+        set: vi.fn(),
+        delete: vi.fn(),
+      };
+      sessionRecovery.store = store as any;
+      agentThat({}, {});
+
+      await getOrCreateSession("T-Fresh", ["node", "a.js"], [], { env: {} } as any, fakeBridge());
+
+      expect(store.set).toHaveBeenCalledWith("T-Fresh", "brand-new");
     });
   });
 

--- a/src/__tests__/sessionStore.test.ts
+++ b/src/__tests__/sessionStore.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { SessionStore, sessionStorePath } from "../sessionStore.js";
+
+describe("sessionStorePath", () => {
+  it("should keep different agents apart in the same workspace", () => {
+    const gemini = sessionStorePath("gemini --acp", "https://ws.example", "/cache");
+    const codex = sessionStorePath("codex --acp", "https://ws.example", "/cache");
+
+    // A session id only means something to the agent that issued it.
+    expect(gemini).not.toBe(codex);
+  });
+
+  it("should keep the same agent's workspaces apart", () => {
+    expect(sessionStorePath("gemini", "https://a.example", "/cache")).not.toBe(
+      sessionStorePath("gemini", "https://b.example", "/cache"),
+    );
+  });
+
+  it("should be stable for the same agent and workspace", () => {
+    expect(sessionStorePath("gemini", "https://a.example", "/cache")).toBe(
+      sessionStorePath("gemini", "https://a.example", "/cache"),
+    );
+  });
+
+  it("should put the file somewhere it belongs", () => {
+    const file = sessionStorePath("gemini", "https://a.example", "/cache");
+
+    expect(path.dirname(file)).toBe(path.join("/cache", "sessions"));
+    expect(file.endsWith(".json")).toBe(true);
+  });
+});
+
+describe("SessionStore", () => {
+  let dir: string;
+  let file: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "acp-sessions-"));
+    file = path.join(dir, "nested", "sessions.json");
+  });
+
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("should remember a session across instances", () => {
+    new SessionStore(file).set("task-1", "sess-1");
+
+    expect(new SessionStore(file).get("task-1")).toBe("sess-1");
+  });
+
+  it("should know nothing before anything has been stored", () => {
+    expect(new SessionStore(file).get("task-1")).toBeUndefined();
+  });
+
+  it("should forget a session on request", () => {
+    const store = new SessionStore(file);
+    store.set("task-1", "sess-1");
+
+    store.delete("task-1");
+
+    expect(store.get("task-1")).toBeUndefined();
+    expect(new SessionStore(file).get("task-1")).toBeUndefined();
+  });
+
+  it("should not rewrite the file for a session it already knows", () => {
+    const store = new SessionStore(file);
+    store.set("task-1", "sess-1");
+    const before = readFileSync(file, "utf-8");
+
+    store.set("task-1", "sess-1");
+    store.delete("task-2");
+
+    expect(readFileSync(file, "utf-8")).toBe(before);
+  });
+
+  it("should start clean when the file cannot be understood", () => {
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(file, "{ not json");
+
+    // Losing this costs context on the next restart; refusing to start would
+    // cost every task.
+    expect(() => new SessionStore(file).get("task-1")).not.toThrow();
+  });
+
+  it("should carry on when the file cannot be written", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    // A path under a regular file can never be created.
+    const blocked = path.join(dir, "blocker");
+    writeFileSync(blocked, "");
+    const store = new SessionStore(path.join(blocked, "sessions.json"));
+
+    expect(() => store.set("task-1", "sess-1")).not.toThrow();
+    expect(store.get("task-1")).toBe("sess-1");
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/src/acpClient.ts
+++ b/src/acpClient.ts
@@ -70,6 +70,9 @@ export class AgentRQACPClient implements acp.Client {
   // serves them all: a listener per request was only ever removed on a matching
   // verdict, so every unanswered request leaked one for the life of the process.
   private pendingPermissions = new Map<string, PendingPermission>();
+  // Sessions whose output is currently the agent replaying old history rather
+  // than saying anything new.
+  private replaySessions = new Set<string>();
   private permissionTimeoutMs: number;
   private cancelSession?: (sessionId: string) => unknown;
   private onModeChanged?: (sessionId: string, modeId: string) => unknown;
@@ -93,6 +96,23 @@ export class AgentRQACPClient implements acp.Client {
    */
   setModeChangeHandler(handler: (sessionId: string, modeId: string) => unknown): void {
     this.onModeChanged = handler;
+  }
+
+  /**
+   * Runs something while ignoring what the agent says on a session.
+   *
+   * `session/load` replays the entire prior conversation as ordinary message
+   * chunks. Buffered as usual, that would land in the task as a brand-new reply
+   * repeating everything already said.
+   */
+  async withRepliesSuppressed<T>(sessionId: string, fn: () => Promise<T>): Promise<T> {
+    this.replaySessions.add(sessionId);
+    try {
+      return await fn();
+    } finally {
+      this.replaySessions.delete(sessionId);
+      this.replyBuffers.delete(sessionId);
+    }
   }
 
   /** How many tool calls are waiting on a human right now. */
@@ -436,6 +456,7 @@ export class AgentRQACPClient implements acp.Client {
         if (update.content.type === "text") {
           process.stdout.write(update.content.text);
           const sid = params.sessionId;
+          if (this.replaySessions.has(sid)) break;
           this.replyBuffers.set(sid, (this.replyBuffers.get(sid) ?? "") + update.content.text);
         }
         break;

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,6 +97,7 @@ import {
 } from "./auth.js";
 import { resolveAgentLaunch } from "./agentInstall.js";
 import { describeAgentInfo } from "./agentInfo.js";
+import { SessionStore, sessionStorePath } from "./sessionStore.js";
 import {
   describeAgents,
   fetchRegistry,
@@ -124,6 +125,13 @@ export const authConfig: { methodId?: string } = {};
 
 /** How long tool calls wait for a human, taken from the CLI at startup. */
 export const permissionConfig: { timeoutMs?: number } = {};
+
+/**
+ * Where task → session pairs are remembered between runs, once main() knows
+ * which agent and workspace this gateway is for. Absent in tests, where there
+ * is nothing to recover and nothing worth writing to disk.
+ */
+export const sessionRecovery: { store?: SessionStore } = {};
 
 /**
  * Whether a human is sitting in front of this process.
@@ -351,6 +359,51 @@ export function shutdownAgent(): void {
   discardAgentRuntime();
 }
 
+/**
+ * Picks up a session the agent still has, from before this gateway started.
+ *
+ * Tries the cheaper route first: `session/resume` continues a conversation
+ * without replaying it, while `session/load` streams the entire history back.
+ * Returns undefined when the agent cannot, or will not, take the session back —
+ * the caller then starts a fresh one.
+ */
+async function recoverSession(
+  runtime: AgentRuntime,
+  sessionId: string,
+  params: AcpNewSessionParams,
+): Promise<{ sessionId: string; modes?: acp.SessionModeState | null } | undefined> {
+  const capabilities = runtime.initResult.agentCapabilities;
+  const sessionCapabilities = (capabilities as { sessionCapabilities?: Record<string, unknown> })
+    ?.sessionCapabilities;
+  const request = { sessionId, cwd: params.cwd, mcpServers: params.mcpServers };
+
+  if (sessionCapabilities?.resume) {
+    try {
+      const resumed = await runtime.connection.resumeSession(request);
+      console.error(`[acp] Resumed session ${sessionId}`);
+      return { sessionId, modes: resumed?.modes };
+    } catch (err) {
+      console.error(`[acp] Could not resume session ${sessionId}:`, err);
+    }
+  }
+
+  if (capabilities?.loadSession) {
+    try {
+      // Loading replays the whole conversation as ordinary message chunks, and
+      // buffering those would re-post the entire prior conversation as a reply.
+      const loaded = await runtime.acpClient.withRepliesSuppressed(sessionId, () =>
+        runtime.connection.loadSession(request),
+      );
+      console.error(`[acp] Loaded session ${sessionId}`);
+      return { sessionId, modes: loaded?.modes };
+    } catch (err) {
+      console.error(`[acp] Could not load session ${sessionId}:`, err);
+    }
+  }
+
+  return undefined;
+}
+
 export async function getOrCreateSession(
   taskId: string | undefined,
   acpCmdArgs: string[],
@@ -372,17 +425,40 @@ export async function getOrCreateSession(
     mcpServers: mapMcpServers(configs, runtime.initResult.agentCapabilities),
   };
 
-  const sessionResult = await createSessionWithAuth(runtime.connection, newSessionParams, {
-    methods: runtime.initResult.authMethods,
-    launch: { command: cmd, args: cmdArgs, env: agentrqConfig.env },
-    preferredId: authConfig.methodId,
-    interactive: isInteractiveTerminal(),
-  });
-  console.error(`[acp] Created session ${sessionResult.sessionId} for task ${key}`);
+  // A session the agent still holds keeps the conversation intact across a
+  // gateway restart. Without it the human replies "yes, go ahead" and the agent
+  // has no idea what "it" refers to.
+  // "default" is a slot in this map, not a task. Treating it as one would post
+  // the agent's replies to a chat called "default".
+  const remembered = taskId ? sessionRecovery.store?.get(taskId) : undefined;
+  let sessionResult:
+    | { sessionId: string; modes?: acp.SessionModeState | null }
+    | undefined;
+  if (remembered && taskId) {
+    runtime.sessionTasks.set(remembered, taskId);
+    sessionResult = await recoverSession(runtime, remembered, newSessionParams);
+    if (!sessionResult) {
+      runtime.sessionTasks.delete(remembered);
+      sessionRecovery.store?.delete(taskId);
+    }
+  }
+
+  if (!sessionResult) {
+    sessionResult = await createSessionWithAuth(runtime.connection, newSessionParams, {
+      methods: runtime.initResult.authMethods,
+      launch: { command: cmd, args: cmdArgs, env: agentrqConfig.env },
+      preferredId: authConfig.methodId,
+      interactive: isInteractiveTerminal(),
+    });
+    console.error(`[acp] Created session ${sessionResult.sessionId} for task ${key}`);
+  }
 
   // "default" is a slot in this map, not a task. Treating it as one would post
   // the agent's replies to a chat called "default".
-  if (taskId) runtime.sessionTasks.set(sessionResult.sessionId, taskId);
+  if (taskId) {
+    sessionRecovery.store?.set(taskId, sessionResult.sessionId);
+    runtime.sessionTasks.set(sessionResult.sessionId, taskId);
+  }
   runtime.sessionModes.set(sessionResult.sessionId, sessionResult.modes);
   await enforceHumanApprovalMode(runtime.connection, sessionResult);
 
@@ -975,6 +1051,9 @@ async function main() {
 
   authConfig.methodId = authMethodId;
   permissionConfig.timeoutMs = options.permissionTimeoutMs;
+  sessionRecovery.store = new SessionStore(
+    sessionStorePath(acpCmdArgs.join(" "), agentrqConfig.url ?? ""),
+  );
 
   const taskQueue = new TaskQueue(maxConcurrency);
 

--- a/src/sessionStore.ts
+++ b/src/sessionStore.ts
@@ -1,0 +1,89 @@
+/**
+ * sessionStore.ts
+ *
+ * Remembers which ACP session belongs to which task, across restarts.
+ *
+ * A session lives inside the agent, not here, and agents that advertise
+ * `session/resume` or `session/load` can pick one up again later. Without a
+ * note of which session was which, a gateway restart loses that: the human
+ * replies "yes, go ahead" and the agent has no idea what "it" refers to.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { createHash } from "node:crypto";
+import * as path from "node:path";
+import { defaultCacheDir } from "./agentInstall.js";
+
+interface StoredSessions {
+  /** taskId → the ACP session that was serving it. */
+  sessions: Record<string, string>;
+}
+
+/**
+ * Where one gateway's sessions are remembered.
+ *
+ * A session id only means something to the agent that issued it, in the
+ * workspace it was created for, so the file is keyed by both. Pointing a
+ * different agent at the same workspace starts from scratch rather than
+ * offering it session ids it has never heard of.
+ */
+export function sessionStorePath(
+  agentCommand: string,
+  workspaceUrl: string,
+  cacheDir: string = path.dirname(defaultCacheDir()),
+): string {
+  const key = createHash("sha256").update(`${agentCommand}\n${workspaceUrl}`).digest("hex");
+  return path.join(cacheDir, "sessions", `${key.slice(0, 16)}.json`);
+}
+
+/** Remembers task → session pairs, on disk, best-effort. */
+export class SessionStore {
+  private sessions: Record<string, string>;
+
+  constructor(private filePath: string) {
+    this.sessions = SessionStore.read(filePath);
+  }
+
+  private static read(filePath: string): Record<string, string> {
+    try {
+      const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as StoredSessions;
+      return parsed.sessions ?? {};
+    } catch {
+      // No file yet, or one that cannot be read. Either way there is nothing to
+      // recover, which is exactly the state before this existed.
+      return {};
+    }
+  }
+
+  /** The session that was serving this task before, if one is remembered. */
+  get(taskId: string): string | undefined {
+    return this.sessions[taskId];
+  }
+
+  set(taskId: string, sessionId: string): void {
+    if (this.sessions[taskId] === sessionId) return;
+    this.sessions[taskId] = sessionId;
+    this.persist();
+  }
+
+  delete(taskId: string): void {
+    if (!(taskId in this.sessions)) return;
+    delete this.sessions[taskId];
+    this.persist();
+  }
+
+  /**
+   * Writes the file, and shrugs if it cannot.
+   *
+   * Losing this costs a conversation's context on the next restart; failing
+   * the task over it would cost the task.
+   */
+  private persist(): void {
+    try {
+      mkdirSync(path.dirname(this.filePath), { recursive: true });
+      writeFileSync(this.filePath, JSON.stringify({ sessions: this.sessions }, null, 2));
+    } catch (err) {
+      console.error(`[acp] Could not remember sessions in ${this.filePath}:`, err);
+    }
+  }
+}


### PR DESCRIPTION
Stacked on #43.

**What changed**

The gateway now remembers which conversation belonged to which task, and picks it back up when it restarts — trying to resume it, then to load it, and only starting fresh if neither works.

**Why changed**

Rescoped after checking what the agent actually supports. The original plan was to close a conversation when a task finished and reopen it on the next message, but a live handshake with `antigravity-acp` shows it does not offer closing at all — while it does offer both ways of picking a conversation back up. So the resource saving moves entirely to the previous PR, and this becomes about the thing that was actually broken: restarting the gateway lost every conversation, so a human replying "yes, go ahead" got an agent with no idea what "it" referred to.

Two traps are handled explicitly. Loading a conversation replays all of it as ordinary agent messages, which would have been posted straight back into the task as a brand-new reply repeating everything already said. And both ways of picking a conversation back up can hand it back in the agent's own default mode — often one that approves tool calls without asking — so the human-approval mode is enforced again on anything recovered.

**Test coverage report**

- New lines introduced: 100%
- Total coverage impact: statements 89.11% → 89.61%, lines 89.04% → 89.55%; 305 → 327 tests, all passing
- Verified end to end against the real `antigravity-acp` agent: told it to remember a number, killed the gateway, started a new one, and asked for the number back. It resumed the same session and answered `8675309`

**Other reports**

The end-to-end run also caught a regression from the previous PR in this stack: a session with no readable task id was reporting itself as a task literally called `default`, which would have sent the agent's replies to a chat of that name. Fixed in #43 where it was introduced, with a test.

TaskID: 0i4ixb9sCBd

Generated with [AgentRQ](https://agentrq.com)