### PR TITLE
feat: let a human stop a running task

### DIFF
--- a/src/__tests__/acpClient.test.ts
+++ b/src/__tests__/acpClient.test.ts
@@ -1214,6 +1214,23 @@ describe("AgentRQACPClient", () => {
       await waiting;
     });
 
+    it("should answer only the session being stopped", async () => {
+      const first = client.requestPermission(params());
+      const second = client.requestPermission(
+        params({ sessionId: "sess-2", toolCall: { toolCallId: "call-2", title: "Bash" } }),
+      );
+      await vi.waitFor(() => expect(client.pendingPermissionCount).toBe(2));
+
+      // One task being stopped must not answer another task's questions.
+      client.cancelPendingPermissions("stopped", "sess-1");
+
+      expect((await first).outcome.outcome).toBe("cancelled");
+      expect(client.pendingPermissionCount).toBe(1);
+
+      client.cancelPendingPermissions("test over");
+      await second;
+    });
+
     it("should say nothing when there is nothing waiting to cancel", () => {
       const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       client.cancelPendingPermissions("nothing doing");

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -22,6 +22,7 @@ import {
   pickHumanApprovalMode,
   enforceHumanApprovalMode,
   shutdownAgent,
+  cancelTask,
   sessionRecovery,
   handleAgentModeChange,
   runAgentCommand,
@@ -1405,6 +1406,44 @@ describe("index", () => {
       await getOrCreateSession("T-Fresh", ["node", "a.js"], [], { env: {} } as any, fakeBridge());
 
       expect(store.set).toHaveBeenCalledWith("T-Fresh", "brand-new");
+    });
+  });
+
+  describe("cancelTask", () => {
+    beforeEach(() => {
+      vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    it("should stop the turn and answer what it was waiting on", async () => {
+      const session: any = {
+        sessionId: "sess-1",
+        connection: { cancel: vi.fn().mockResolvedValue(undefined) },
+        acpClient: { cancelPendingPermissions: vi.fn() },
+      };
+      activeSessions.set("T-Stop", session);
+
+      await cancelTask("T-Stop");
+
+      // Cancelling without answering leaves the tool call waiting forever.
+      expect(session.acpClient.cancelPendingPermissions).toHaveBeenCalledWith(
+        expect.stringContaining("T-Stop"),
+        "sess-1",
+      );
+      expect(session.connection.cancel).toHaveBeenCalledWith({ sessionId: "sess-1" });
+    });
+
+    it("should do nothing for a task that is not running", async () => {
+      await expect(cancelTask("T-Unknown")).resolves.toBeUndefined();
+    });
+
+    it("should survive an agent that cannot be told to stop", async () => {
+      activeSessions.set("T-Broken", {
+        sessionId: "sess-1",
+        connection: { cancel: vi.fn().mockRejectedValue(new Error("pipe closed")) },
+        acpClient: { cancelPendingPermissions: vi.fn() },
+      } as any);
+
+      await expect(cancelTask("T-Broken")).resolves.toBeUndefined();
     });
   });
 

--- a/src/__tests__/mcpClient.test.ts
+++ b/src/__tests__/mcpClient.test.ts
@@ -78,7 +78,7 @@ describe("MCPBridge", () => {
       expect(Client).toHaveBeenCalled();
       expect(StreamableHTTPClientTransport).toHaveBeenCalled();
       expect(lastMockClient.connect).toHaveBeenCalled();
-      expect(lastMockClient.setNotificationHandler).toHaveBeenCalledTimes(2);
+      expect(lastMockClient.setNotificationHandler).toHaveBeenCalledTimes(3);
       expect((bridge as any).isConnected).toBe(true);
     });
 
@@ -274,6 +274,54 @@ describe("MCPBridge", () => {
     await vi.advanceTimersByTimeAsync(0);
 
     expect(reconnected).toHaveBeenCalledTimes(1);
+  });
+
+  describe("notifications from the workspace", () => {
+    /** Runs the handler the bridge registered for one notification method. */
+    async function deliver(bridge: MCPBridge, method: string, params: unknown) {
+      await bridge.connect();
+      const registered = lastMockClient.setNotificationHandler.mock.calls.find(
+        ([schema]: any[]) => schema.shape.method.value === method,
+      );
+      if (!registered) throw new Error(`no handler registered for ${method}`);
+      registered[1]({ method, params });
+    }
+
+    it("should announce a task the human sent", async () => {
+      const bridge = new MCPBridge(config);
+      const heard = vi.fn();
+      bridge.on("task", heard);
+
+      await deliver(bridge, "notifications/claude/channel", {
+        content: "do the thing",
+        meta: { chat_id: "T1" },
+      });
+
+      expect(heard).toHaveBeenCalledWith({ content: "do the thing", meta: { chat_id: "T1" } });
+    });
+
+    it("should announce a permission verdict", async () => {
+      const bridge = new MCPBridge(config);
+      const heard = vi.fn();
+      bridge.on("verdict", heard);
+
+      await deliver(bridge, "notifications/claude/channel/permission", {
+        request_id: "req-1",
+        behavior: "allow",
+      });
+
+      expect(heard).toHaveBeenCalledWith({ requestId: "req-1", behavior: "allow" });
+    });
+
+    it("should announce a task the human stopped", async () => {
+      const bridge = new MCPBridge(config);
+      const heard = vi.fn();
+      bridge.on("cancel", heard);
+
+      await deliver(bridge, "notifications/claude/channel/cancel", { task_id: "T1" });
+
+      expect(heard).toHaveBeenCalledWith({ taskId: "T1" });
+    });
   });
 
 });

--- a/src/acpClient.ts
+++ b/src/acpClient.ts
@@ -129,17 +129,20 @@ export class AgentRQACPClient implements acp.Client {
   }
 
   /**
-   * Answers every waiting tool call with `cancelled`.
+   * Answers waiting tool calls with `cancelled`.
    *
-   * Used when the agent is gone: nothing will ever act on those answers, but
-   * the promises must settle or their task-queue slots are held forever.
+   * With `sessionId`, only that session's — one task being stopped must not
+   * answer another task's questions. Without it, every one: used when the agent
+   * itself is gone, where nothing will act on those answers but the promises
+   * must settle or their task-queue slots are held forever.
    */
-  cancelPendingPermissions(reason: string): void {
-    if (this.pendingPermissions.size === 0) return;
-    console.error(
-      `[acp] Cancelling ${this.pendingPermissions.size} waiting permission request(s): ${reason}`,
+  cancelPendingPermissions(reason: string, sessionId?: string): void {
+    const affected = [...this.pendingPermissions.values()].filter(
+      (pending) => sessionId === undefined || pending.sessionId === sessionId,
     );
-    for (const pending of [...this.pendingPermissions.values()]) {
+    if (affected.length === 0) return;
+    console.error(`[acp] Cancelling ${affected.length} waiting permission request(s): ${reason}`);
+    for (const pending of affected) {
       pending.settle({ outcome: "cancelled" });
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -353,6 +353,32 @@ export async function getAgentRuntime(
   return agentRuntimeStarting;
 }
 
+/**
+ * Stops whatever the agent is doing for one task, because a human said so.
+ *
+ * Answers the tool call it may be waiting on before cancelling the turn: a
+ * cancelled turn leaves that request unanswered otherwise, and the spec treats
+ * `cancelled` as exactly the answer a client gives because it cancelled.
+ */
+export async function cancelTask(taskId: string): Promise<void> {
+  const session = activeSessions.get(taskId);
+  if (!session) {
+    console.error(`[bridge] Nothing to stop for task ${taskId}`);
+    return;
+  }
+
+  console.error(`[bridge] Stopping task ${taskId} at the human's request`);
+  session.acpClient.cancelPendingPermissions(
+    `task ${taskId} stopped from the dashboard`,
+    session.sessionId,
+  );
+  try {
+    await session.connection.cancel({ sessionId: session.sessionId });
+  } catch (err) {
+    console.error(`[bridge] Failed to stop task ${taskId}:`, err);
+  }
+}
+
 /** Stops the agent, if one is running. Used when the gateway itself is done. */
 export function shutdownAgent(): void {
   agentRuntime?.process.kill();
@@ -1119,6 +1145,11 @@ async function main() {
       }).catch((err) => {
         console.error("[bridge] Error queuing task:", err);
       });
+    });
+
+    // A human stopping a task in the dashboard.
+    mcpBridge.on("cancel", ({ taskId }: { taskId: string }) => {
+      void cancelTask(taskId);
     });
 
     // Initial check for a pending task

--- a/src/mcpClient.ts
+++ b/src/mcpClient.ts
@@ -143,6 +143,20 @@ export class MCPBridge extends EventEmitter {
       },
     );
 
+    // Set notification handler for a human stopping a task from the dashboard.
+    this.client.setNotificationHandler(
+      z.object({
+        method: z.literal("notifications/claude/channel/cancel"),
+        params: z.object({
+          task_id: z.string(),
+        }),
+      }),
+      (notification) => {
+        console.error("[mcp] Received cancel request");
+        this.emit("cancel", { taskId: notification.params.task_id });
+      },
+    );
+
     // Set notification handler for permission verdicts
     this.client.setNotificationHandler(
       z.object({


### PR DESCRIPTION
Stacked on #44. Gateway half of the stop button; the workspace half is a separate change in the agentrq repo.

**What changed**

The gateway now listens for a request from the workspace to stop a task, and ends that task's turn — answering the approval it may have been waiting on first.

**Why changed**

There was no way to stop a turn once it started. A task that had gone wrong ran to its own conclusion, and while it did, it held one of the slots that decide how much else can run. This was one of the original gaps: the protocol's cancel was never sent.

Answering the outstanding approval as cancelled matters twice over. Cancelling alone leaves that request unanswered forever, and the protocol treats "cancelled" as precisely the answer a client gives *because* it cancelled the turn. The answering is scoped to the stopped task's own session, since one agent process now serves every task and cancelling indiscriminately would answer other tasks' questions too.

It is deliberately a new kind of message rather than a new approval outcome: the existing outcome field is a bare string where anything that is not "allow" reads as a refusal, and a refusal lets the turn continue rather than ending it.

**Test coverage report**

- New lines introduced: 100%
- Total coverage impact: statements 89.61% → 90.13%, lines 89.55% → 90.13%; 327 → 334 tests, all passing (also backfills tests for the two pre-existing notification handlers, which had none)
- Verified end to end against the real `antigravity-acp` agent: with a task waiting on an approval, a stop request answered the pending approval as cancelled, the cancellation reached the agent (`Antigravity SDK prompt cancelled`), the turn ended, and the workspace was told it had been cut short

TaskID: 0i4izEeJzdp

Generated with [AgentRQ](https://agentrq.com)