### PR TITLE
chore: bump version to 0.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install -g @agentrq/acp-gateway
 
 ## Current Version
 
-`0.2.4`
+`0.2.5`
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentrq/acp-gateway",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.4.0",
         "@modelcontextprotocol/sdk": "^1.30.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "ACP+MCP bridge CLI for agentrq workspaces",
   "type": "module",
   "publishConfig": {

--- a/src/mcpClient.ts
+++ b/src/mcpClient.ts
@@ -95,7 +95,7 @@ export class MCPBridge extends EventEmitter {
     this.client = new Client(
       {
         name: "acp-gateway",
-        version: "0.2.4",
+        version: "0.2.5",
       },
       {
         capabilities: {},


### PR DESCRIPTION
## What changed

Bumped the package patch version from 0.2.4 to 0.2.5, keeping every place the version is stated in sync — the package manifest and lockfile, the version noted in the readme, and the client identity the gateway reports to the MCP server.

## Why changed

Prepares the next patch release so the accumulated fixes since 0.2.4 can be published to npm.

## Test coverage report

- New lines introduced: 100% — the change only updates existing version literals, no new logic or branches.
- Total coverage impact: none. Statements 88.24%, Branches 90.51%, Functions 86.62%, Lines 88.18% — identical before and after.
- Full suite green: 294 tests across 9 files passed; `tsc --noEmit` clean.

## Other reports

Version string verified consistent across all four references; diff shape matches the previous 0.2.4 bump exactly (4 files, 5 insertions, 5 deletions).

TaskID: 0i7mq4qjD1t

---

Generated with [AgentRQ](https://agentrq.com)