### PR TITLE
feat(cancellation): bridge external task cancellation events to ACP session/cancel (0i7xRDRmfdR)

### DIFF
--- a/src/__tests__/acpClient.test.ts
+++ b/src/__tests__/acpClient.test.ts
@@ -1210,6 +1210,29 @@ describe("AgentRQACPClient", () => {
       expect(client.pendingPermissionCount).toBe(0);
     });
 
+    it("should settle waiting permissions even if session/cancel never returns", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      // An agent wedged on its stdin: the write goes out, nothing comes back.
+      // The permissions must still settle or their queue slots are held forever.
+      client.setSessionCanceller(() => new Promise(() => {}));
+
+      const waiting = client.requestPermission(params({ sessionId: "sess-1" }));
+      await vi.waitFor(() => expect(client.pendingPermissionCount).toBe(1));
+
+      vi.useFakeTimers();
+      try {
+        const cancelling = client.cancelTurn("sess-1");
+        await vi.advanceTimersByTimeAsync(5000);
+        await cancelling;
+      } finally {
+        vi.useRealTimers();
+      }
+
+      expect((await waiting).outcome.outcome).toBe("cancelled");
+      expect(client.pendingPermissionCount).toBe(0);
+      errorSpy.mockRestore();
+    });
+
     it("should handle cancelTurn with undefined sessionId or no canceller gracefully", async () => {
       await expect(client.cancelTurn(undefined)).resolves.toBeUndefined();
 

--- a/src/__tests__/acpClient.test.ts
+++ b/src/__tests__/acpClient.test.ts
@@ -1161,15 +1161,19 @@ describe("AgentRQACPClient", () => {
     it("should cancel only the pending permissions for the specified session", async () => {
       const waitSess1 = client.requestPermission(params({ sessionId: "sess-1", toolCall: { toolCallId: "call-1", title: "Bash" } }));
       const waitSess2 = client.requestPermission(params({ sessionId: "sess-2", toolCall: { toolCallId: "call-2", title: "Bash" } }));
-      await vi.waitFor(() => expect(client.pendingPermissionCount).toBe(2));
+      const waitNoSess = client.requestPermission(params({ sessionId: undefined, toolCall: { toolCallId: "call-3", title: "Bash" } }));
+      await vi.waitFor(() => expect(client.pendingPermissionCount).toBe(3));
 
       client.cancelPendingPermissions("task cancelled", "sess-1");
 
       expect((await waitSess1).outcome.outcome).toBe("cancelled");
-      expect(client.pendingPermissionCount).toBe(1);
+      expect(client.pendingPermissionCount).toBe(2);
 
-      answerWith("allow");
+      // Requests with undefined sessionId should NOT be cancelled by a session-scoped cancel
+      mcpBridge.emit("verdict", { requestId: "sess-2:call-2", behavior: "allow" });
       expect((await waitSess2).outcome.outcome).toBe("selected");
+      mcpBridge.emit("verdict", { requestId: "call-3", behavior: "allow" });
+      expect((await waitNoSess).outcome.outcome).toBe("selected");
       expect(client.pendingPermissionCount).toBe(0);
     });
 
@@ -1184,16 +1188,24 @@ describe("AgentRQACPClient", () => {
       expect((await waiting).outcome.outcome).toBe("selected");
     });
 
-    it("should cancel turn and pending permissions via cancelTurn", async () => {
-      const cancelSession = vi.fn().mockResolvedValue(undefined);
+    it("should send session/cancel RPC before settling pending permissions", async () => {
+      const callOrder: string[] = [];
+      const cancelSession = vi.fn().mockImplementation(async () => {
+        callOrder.push("cancelRPC");
+      });
       client.setSessionCanceller(cancelSession);
 
-      const waiting = client.requestPermission(params({ sessionId: "sess-1" }));
+      const waiting = client.requestPermission(params({ sessionId: "sess-1" })).then((res) => {
+        callOrder.push("settledPermission");
+        return res;
+      });
       await vi.waitFor(() => expect(client.pendingPermissionCount).toBe(1));
 
       await client.cancelTurn("sess-1");
+      const res = await waiting;
 
-      expect((await waiting).outcome.outcome).toBe("cancelled");
+      expect(callOrder).toEqual(["cancelRPC", "settledPermission"]);
+      expect(res.outcome.outcome).toBe("cancelled");
       expect(cancelSession).toHaveBeenCalledWith("sess-1");
       expect(client.pendingPermissionCount).toBe(0);
     });

--- a/src/__tests__/acpClient.test.ts
+++ b/src/__tests__/acpClient.test.ts
@@ -1157,6 +1157,68 @@ describe("AgentRQACPClient", () => {
       await waiting;
     });
 
+
+    it("should cancel only the pending permissions for the specified session", async () => {
+      const waitSess1 = client.requestPermission(params({ sessionId: "sess-1", toolCall: { toolCallId: "call-1", title: "Bash" } }));
+      const waitSess2 = client.requestPermission(params({ sessionId: "sess-2", toolCall: { toolCallId: "call-2", title: "Bash" } }));
+      await vi.waitFor(() => expect(client.pendingPermissionCount).toBe(2));
+
+      client.cancelPendingPermissions("task cancelled", "sess-1");
+
+      expect((await waitSess1).outcome.outcome).toBe("cancelled");
+      expect(client.pendingPermissionCount).toBe(1);
+
+      answerWith("allow");
+      expect((await waitSess2).outcome.outcome).toBe("selected");
+      expect(client.pendingPermissionCount).toBe(0);
+    });
+
+    it("should do nothing if sessionId does not match any waiting permissions", async () => {
+      const waiting = client.requestPermission(params({ sessionId: "sess-1" }));
+      await vi.waitFor(() => expect(client.pendingPermissionCount).toBe(1));
+
+      client.cancelPendingPermissions("task cancelled", "sess-999");
+      expect(client.pendingPermissionCount).toBe(1);
+
+      answerWith("allow");
+      expect((await waiting).outcome.outcome).toBe("selected");
+    });
+
+    it("should cancel turn and pending permissions via cancelTurn", async () => {
+      const cancelSession = vi.fn().mockResolvedValue(undefined);
+      client.setSessionCanceller(cancelSession);
+
+      const waiting = client.requestPermission(params({ sessionId: "sess-1" }));
+      await vi.waitFor(() => expect(client.pendingPermissionCount).toBe(1));
+
+      await client.cancelTurn("sess-1");
+
+      expect((await waiting).outcome.outcome).toBe("cancelled");
+      expect(cancelSession).toHaveBeenCalledWith("sess-1");
+      expect(client.pendingPermissionCount).toBe(0);
+    });
+
+    it("should handle cancelTurn with undefined sessionId or no canceller gracefully", async () => {
+      await expect(client.cancelTurn(undefined)).resolves.toBeUndefined();
+
+      const freshClient = new AgentRQACPClient(mcpBridge as unknown as MCPBridge, () => "task-1");
+      await expect(freshClient.cancelTurn("sess-1")).resolves.toBeUndefined();
+    });
+
+    it("should log error if cancelSession rejects during cancelTurn", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      client.setSessionCanceller(() => {
+        throw new Error("cancel RPC failed");
+      });
+
+      await client.cancelTurn("sess-1");
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to cancel turn for session sess-1:"),
+        expect.any(Error)
+      );
+      errorSpy.mockRestore();
+    });
+
     it("should say nothing when there is nothing waiting to cancel", () => {
       const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       client.cancelPendingPermissions("nothing doing");

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -24,6 +24,8 @@ import {
   enforceHumanApprovalMode,
   handleAgentModeChange,
   runAgentCommand,
+  findActiveSession,
+  handleTaskCancellation,
 } from "../index.js";
 import { AUTH_REQUIRED_CODE } from "../auth.js";
 import type { McpServerConfig } from "../config.js";
@@ -1201,6 +1203,98 @@ describe("index", () => {
       );
     });
   });
+
+  describe("task cancellation handling", () => {
+    let errorSpy: any;
+
+    beforeEach(() => {
+      activeSessions.clear();
+      errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      activeSessions.clear();
+      errorSpy.mockRestore();
+    });
+
+    describe("findActiveSession", () => {
+      it("should find session by direct task key", () => {
+        const mockSession: any = { sessionId: "sess-1", acpClient: { cancelTurn: vi.fn() } };
+        activeSessions.set("task-1", mockSession);
+
+        expect(findActiveSession("task-1")).toBe(mockSession);
+      });
+
+      it("should find session by sessionId match", () => {
+        const mockSession: any = { sessionId: "sess-custom", acpClient: { cancelTurn: vi.fn() } };
+        activeSessions.set("key-other", mockSession);
+
+        expect(findActiveSession("sess-custom")).toBe(mockSession);
+      });
+
+      it("should return the single session if no taskId is provided", () => {
+        const mockSession: any = { sessionId: "sess-only", acpClient: { cancelTurn: vi.fn() } };
+        activeSessions.set("default", mockSession);
+
+        expect(findActiveSession(undefined)).toBe(mockSession);
+      });
+
+      it("should return undefined if no taskId provided and multiple or zero sessions exist", () => {
+        expect(findActiveSession(undefined)).toBeUndefined();
+
+        activeSessions.set("task-1", { sessionId: "s1" } as any);
+        activeSessions.set("task-2", { sessionId: "s2" } as any);
+        expect(findActiveSession(undefined)).toBeUndefined();
+      });
+
+      it("should return undefined if taskId is not found", () => {
+        activeSessions.set("task-1", { sessionId: "s1" } as any);
+        expect(findActiveSession("task-nonexistent")).toBeUndefined();
+      });
+    });
+
+    describe("handleTaskCancellation", () => {
+      it("should cancel turn on the matched active session", async () => {
+        const cancelTurn = vi.fn().mockResolvedValue(undefined);
+        const mockSession: any = {
+          sessionId: "sess-100",
+          acpClient: { cancelTurn },
+        };
+        activeSessions.set("task-100", mockSession);
+
+        await handleTaskCancellation("task-100", "cancelled by user");
+
+        expect(cancelTurn).toHaveBeenCalledWith("sess-100");
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining("Cancelling session sess-100 for task task-100 (cancelled by user)")
+        );
+      });
+
+      it("should log when task to cancel is not found", async () => {
+        await handleTaskCancellation("task-missing");
+
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining("Received cancellation for task task-missing, but no active session found")
+        );
+      });
+
+      it("should cancel all active sessions when taskId is omitted", async () => {
+        const cancel1 = vi.fn().mockResolvedValue(undefined);
+        const cancel2 = vi.fn().mockResolvedValue(undefined);
+        activeSessions.set("t1", { sessionId: "s1", acpClient: { cancelTurn: cancel1 } } as any);
+        activeSessions.set("t2", { sessionId: "s2", acpClient: { cancelTurn: cancel2 } } as any);
+
+        await handleTaskCancellation(undefined, "server shutdown");
+
+        expect(cancel1).toHaveBeenCalledWith("s1");
+        expect(cancel2).toHaveBeenCalledWith("s2");
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining("Received cancellation with no taskId (server shutdown), cancelling all active sessions")
+        );
+      });
+    });
+  });
+
   describe("handleAgentModeChange", () => {
     const modes: any = {
       currentModeId: "ask",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -26,7 +26,10 @@ import {
   runAgentCommand,
   findActiveSession,
   handleTaskCancellation,
-  cancelledTaskIds,
+  cancelledTaskSeq,
+  markTaskCancelled,
+  isTaskCancelled,
+  nextTaskSeq,
 } from "../index.js";
 import { AUTH_REQUIRED_CODE } from "../auth.js";
 import type { McpServerConfig } from "../config.js";
@@ -1247,6 +1250,14 @@ describe("index", () => {
         expect(findActiveSession("task-new-id")).toBe(mockSession);
       });
 
+      it("should not fall back to a session that belongs to a different task", () => {
+        // Task A is running; a cancel for queued task B must not abort it.
+        const sessionA: any = { sessionId: "sess-a", acpClient: { cancelTurn: vi.fn() } };
+        activeSessions.set("task-a", sessionA);
+
+        expect(findActiveSession("task-b")).toBeUndefined();
+      });
+
       it("should return undefined if taskId is not found when multiple sessions exist", () => {
         activeSessions.set("task-1", { sessionId: "s1" } as any);
         activeSessions.set("task-2", { sessionId: "s2" } as any);
@@ -1272,26 +1283,64 @@ describe("index", () => {
         );
       });
 
-      it("should record taskId in cancelledTaskIds so queued tasks are skipped", async () => {
-        cancelledTaskIds.clear();
-        await handleTaskCancellation("task-queued-1");
-        expect(cancelledTaskIds.has("task-queued-1")).toBe(true);
-
+      it("should skip a task cancelled while it was still being fetched", async () => {
+        cancelledTaskSeq.clear();
         const promptMock = vi.fn();
         const switcher: any = { ensureForTask: vi.fn().mockResolvedValue("s-q1") };
         const acpClient: any = { flushReply: vi.fn(), reportStopReason: vi.fn() };
         const connection: any = { prompt: promptMock };
         const bridge: any = {
-          callTool: vi.fn().mockResolvedValue({
-            content: [{ type: "text", text: "task task-queued-1: do work" }],
+          // The cancel lands while the poll is in flight — the task has no
+          // session yet, so nothing but this flag can stop it.
+          callTool: vi.fn().mockImplementation(async () => {
+            await handleTaskCancellation("task-queued-1");
+            return { content: [{ type: "text", text: "task task-queued-1: do work" }] };
           }),
         };
 
         await checkForNextTask(bridge, connection, switcher, acpClient);
 
-        // Since it was cancelled, prompt should NOT be called
         expect(promptMock).not.toHaveBeenCalled();
-        expect(cancelledTaskIds.has("task-queued-1")).toBe(false);
+      });
+
+      it("should not swallow work queued after the cancellation", async () => {
+        // agentrq reuses a chat's id as the task id, so the id cancelled a
+        // moment ago is the same id the user's next message arrives under.
+        cancelledTaskSeq.clear();
+        await handleTaskCancellation("task-queued-2");
+
+        const promptMock = vi.fn().mockResolvedValue({ stopReason: "end_turn" });
+        const switcher: any = { ensureForTask: vi.fn().mockResolvedValue("s-q2") };
+        const acpClient: any = { flushReply: vi.fn(), reportStopReason: vi.fn() };
+        const connection: any = { prompt: promptMock };
+        const bridge: any = {
+          callTool: vi.fn().mockResolvedValue({
+            content: [{ type: "text", text: "task task-queued-2: fresh work" }],
+          }),
+        };
+
+        await checkForNextTask(bridge, connection, switcher, acpClient);
+
+        expect(promptMock).toHaveBeenCalled();
+      });
+
+      it("should forget the oldest cancellations rather than grow forever", async () => {
+        cancelledTaskSeq.clear();
+        for (let i = 0; i < 250; i++) markTaskCancelled(`task-${i}`);
+
+        expect(cancelledTaskSeq.size).toBe(200);
+        expect(cancelledTaskSeq.has("task-0")).toBe(false);
+        expect(cancelledTaskSeq.has("task-249")).toBe(true);
+      });
+
+      it("should only stop the notification that was queued before the cancel", async () => {
+        cancelledTaskSeq.clear();
+        const older = nextTaskSeq();
+        await handleTaskCancellation("task-two-turns");
+        const newer = nextTaskSeq();
+
+        expect(isTaskCancelled("task-two-turns", older)).toBe(true);
+        expect(isTaskCancelled("task-two-turns", newer)).toBe(false);
       });
 
       it("should log when task to cancel is not found", async () => {
@@ -1325,7 +1374,7 @@ describe("index", () => {
         expect(cancel1).not.toHaveBeenCalled();
         expect(cancel2).not.toHaveBeenCalled();
         expect(errorSpy).toHaveBeenCalledWith(
-          expect.stringContaining("2 active sessions found (skipping to avoid aborting unrelated tasks)")
+          expect.stringContaining("but 2 sessions are active (skipping to avoid aborting unrelated tasks)")
         );
       });
     });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -26,6 +26,7 @@ import {
   runAgentCommand,
   findActiveSession,
   handleTaskCancellation,
+  cancelledTaskIds,
 } from "../index.js";
 import { AUTH_REQUIRED_CODE } from "../auth.js";
 import type { McpServerConfig } from "../config.js";
@@ -1239,17 +1240,18 @@ describe("index", () => {
         expect(findActiveSession(undefined)).toBe(mockSession);
       });
 
-      it("should return undefined if no taskId provided and multiple or zero sessions exist", () => {
-        expect(findActiveSession(undefined)).toBeUndefined();
+      it("should fallback to default keyed session when taskId is given but only 1 session exists", () => {
+        const mockSession: any = { sessionId: "s1", acpClient: { cancelTurn: vi.fn() } };
+        activeSessions.set("default", mockSession);
 
-        activeSessions.set("task-1", { sessionId: "s1" } as any);
-        activeSessions.set("task-2", { sessionId: "s2" } as any);
-        expect(findActiveSession(undefined)).toBeUndefined();
+        expect(findActiveSession("task-new-id")).toBe(mockSession);
       });
 
-      it("should return undefined if taskId is not found", () => {
+      it("should return undefined if taskId is not found when multiple sessions exist", () => {
         activeSessions.set("task-1", { sessionId: "s1" } as any);
+        activeSessions.set("task-2", { sessionId: "s2" } as any);
         expect(findActiveSession("task-nonexistent")).toBeUndefined();
+        expect(findActiveSession(undefined)).toBeUndefined();
       });
     });
 
@@ -1270,6 +1272,28 @@ describe("index", () => {
         );
       });
 
+      it("should record taskId in cancelledTaskIds so queued tasks are skipped", async () => {
+        cancelledTaskIds.clear();
+        await handleTaskCancellation("task-queued-1");
+        expect(cancelledTaskIds.has("task-queued-1")).toBe(true);
+
+        const promptMock = vi.fn();
+        const switcher: any = { ensureForTask: vi.fn().mockResolvedValue("s-q1") };
+        const acpClient: any = { flushReply: vi.fn(), reportStopReason: vi.fn() };
+        const connection: any = { prompt: promptMock };
+        const bridge: any = {
+          callTool: vi.fn().mockResolvedValue({
+            content: [{ type: "text", text: "task task-queued-1: do work" }],
+          }),
+        };
+
+        await checkForNextTask(bridge, connection, switcher, acpClient);
+
+        // Since it was cancelled, prompt should NOT be called
+        expect(promptMock).not.toHaveBeenCalled();
+        expect(cancelledTaskIds.has("task-queued-1")).toBe(false);
+      });
+
       it("should log when task to cancel is not found", async () => {
         await handleTaskCancellation("task-missing");
 
@@ -1278,18 +1302,30 @@ describe("index", () => {
         );
       });
 
-      it("should cancel all active sessions when taskId is omitted", async () => {
+      it("should cancel the single session when taskId is omitted and only 1 session exists", async () => {
+        const cancel1 = vi.fn().mockResolvedValue(undefined);
+        activeSessions.set("t1", { sessionId: "s1", acpClient: { cancelTurn: cancel1 } } as any);
+
+        await handleTaskCancellation(undefined, "single shutdown");
+
+        expect(cancel1).toHaveBeenCalledWith("s1");
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining("Received cancellation with no taskId (single shutdown). Cancelling active session s1...")
+        );
+      });
+
+      it("should fail closed and not cancel anything when taskId is omitted and multiple sessions exist", async () => {
         const cancel1 = vi.fn().mockResolvedValue(undefined);
         const cancel2 = vi.fn().mockResolvedValue(undefined);
         activeSessions.set("t1", { sessionId: "s1", acpClient: { cancelTurn: cancel1 } } as any);
         activeSessions.set("t2", { sessionId: "s2", acpClient: { cancelTurn: cancel2 } } as any);
 
-        await handleTaskCancellation(undefined, "server shutdown");
+        await handleTaskCancellation(undefined, "multiple active");
 
-        expect(cancel1).toHaveBeenCalledWith("s1");
-        expect(cancel2).toHaveBeenCalledWith("s2");
+        expect(cancel1).not.toHaveBeenCalled();
+        expect(cancel2).not.toHaveBeenCalled();
         expect(errorSpy).toHaveBeenCalledWith(
-          expect.stringContaining("Received cancellation with no taskId (server shutdown), cancelling all active sessions")
+          expect.stringContaining("2 active sessions found (skipping to avoid aborting unrelated tasks)")
         );
       });
     });

--- a/src/__tests__/mcpClient.test.ts
+++ b/src/__tests__/mcpClient.test.ts
@@ -262,14 +262,22 @@ describe("MCPBridge", () => {
   });
 
   describe("task cancellation notifications", () => {
+  function getCancelNotificationHandler() {
+    for (const call of lastMockClient.setNotificationHandler.mock.calls) {
+      const schema = call[0];
+      try {
+        const parsed = schema.safeParse({ method: "notifications/claude/channel/cancel" });
+        if (parsed.success) return call[1];
+      } catch {}
+    }
+    return undefined;
+  }
+
     it("should emit cancel event when notifications/claude/channel/cancel is received with task_id", async () => {
       const bridge = new MCPBridge(config);
       await bridge.connect();
 
-      const cancelHandler = lastMockClient.setNotificationHandler.mock.calls.find(
-        (call: any[]) => call[0]?.shape?.method?._def?.value === "notifications/claude/channel/cancel" ||
-                         call[1] && call[0]?.description?.includes?.("cancel")
-      )?.[1] || lastMockClient.setNotificationHandler.mock.calls[2][1];
+      const cancelHandler = getCancelNotificationHandler();
 
       const onCancel = vi.fn();
       bridge.on("cancel", onCancel);
@@ -285,11 +293,11 @@ describe("MCPBridge", () => {
       });
     });
 
-    it("should extract taskId from taskId, chat_id, or meta", async () => {
+        it("should extract taskId from taskId, chat_id, or meta", async () => {
       const bridge = new MCPBridge(config);
       await bridge.connect();
 
-      const cancelHandler = lastMockClient.setNotificationHandler.mock.calls[2][1];
+      const cancelHandler = getCancelNotificationHandler();
       const onCancel = vi.fn();
       bridge.on("cancel", onCancel);
 
@@ -320,6 +328,16 @@ describe("MCPBridge", () => {
       });
       expect(onCancel).toHaveBeenLastCalledWith({
         taskId: "meta-789",
+        reason: undefined,
+      });
+
+      // _meta.chat_id (MCP standard location)
+      cancelHandler({
+        method: "notifications/claude/channel/cancel",
+        params: { _meta: { chat_id: "meta-under" } },
+      });
+      expect(onCancel).toHaveBeenLastCalledWith({
+        taskId: "meta-under",
         reason: undefined,
       });
 

--- a/src/__tests__/mcpClient.test.ts
+++ b/src/__tests__/mcpClient.test.ts
@@ -78,7 +78,7 @@ describe("MCPBridge", () => {
       expect(Client).toHaveBeenCalled();
       expect(StreamableHTTPClientTransport).toHaveBeenCalled();
       expect(lastMockClient.connect).toHaveBeenCalled();
-      expect(lastMockClient.setNotificationHandler).toHaveBeenCalledTimes(2);
+      expect(lastMockClient.setNotificationHandler).toHaveBeenCalledTimes(3);
       expect((bridge as any).isConnected).toBe(true);
     });
 
@@ -260,6 +260,81 @@ describe("MCPBridge", () => {
       });
     });
   });
+
+  describe("task cancellation notifications", () => {
+    it("should emit cancel event when notifications/claude/channel/cancel is received with task_id", async () => {
+      const bridge = new MCPBridge(config);
+      await bridge.connect();
+
+      const cancelHandler = lastMockClient.setNotificationHandler.mock.calls.find(
+        (call: any[]) => call[0]?.shape?.method?._def?.value === "notifications/claude/channel/cancel" ||
+                         call[1] && call[0]?.description?.includes?.("cancel")
+      )?.[1] || lastMockClient.setNotificationHandler.mock.calls[2][1];
+
+      const onCancel = vi.fn();
+      bridge.on("cancel", onCancel);
+
+      cancelHandler({
+        method: "notifications/claude/channel/cancel",
+        params: { task_id: "task-123", reason: "user aborted" },
+      });
+
+      expect(onCancel).toHaveBeenCalledWith({
+        taskId: "task-123",
+        reason: "user aborted",
+      });
+    });
+
+    it("should extract taskId from taskId, chat_id, or meta", async () => {
+      const bridge = new MCPBridge(config);
+      await bridge.connect();
+
+      const cancelHandler = lastMockClient.setNotificationHandler.mock.calls[2][1];
+      const onCancel = vi.fn();
+      bridge.on("cancel", onCancel);
+
+      // taskId property
+      cancelHandler({
+        method: "notifications/claude/channel/cancel",
+        params: { taskId: "task-camel" },
+      });
+      expect(onCancel).toHaveBeenLastCalledWith({
+        taskId: "task-camel",
+        reason: undefined,
+      });
+
+      // chat_id property
+      cancelHandler({
+        method: "notifications/claude/channel/cancel",
+        params: { chat_id: "chat-456" },
+      });
+      expect(onCancel).toHaveBeenLastCalledWith({
+        taskId: "chat-456",
+        reason: undefined,
+      });
+
+      // meta.chat_id
+      cancelHandler({
+        method: "notifications/claude/channel/cancel",
+        params: { meta: { chat_id: "meta-789" } },
+      });
+      expect(onCancel).toHaveBeenLastCalledWith({
+        taskId: "meta-789",
+        reason: undefined,
+      });
+
+      // empty params
+      cancelHandler({
+        method: "notifications/claude/channel/cancel",
+        params: undefined,
+      });
+      expect(onCancel).toHaveBeenLastCalledWith({
+        taskId: undefined,
+        reason: undefined,
+      });
+    });
+  });
+
   it("should announce a reconnection, but not a first connection", async () => {
     const bridge = new MCPBridge(config);
     const reconnected = vi.fn();

--- a/src/acpClient.ts
+++ b/src/acpClient.ts
@@ -13,6 +13,9 @@ import * as path from "node:path";
 /** Identifies a tool call routed through an agentrq MCP server. */
 const AGENTRQ_TOOL_PATTERN = /agentrq-[a-zA-Z0-9]{11}/;
 
+/** How long to wait for `session/cancel` before settling permissions regardless. */
+const CANCEL_SESSION_TIMEOUT_MS = 5000;
+
 /**
  * What a turn ending in anything but `end_turn` means, in the human's terms.
  *
@@ -163,14 +166,36 @@ export class AgentRQACPClient implements acp.Client {
   /** Stops the agent's current turn and cancels any pending permissions for the session. */
   async cancelTurn(sessionId: string | undefined): Promise<void> {
     if (!sessionId) return;
-    if (this.cancelSession) {
-      try {
-        await this.cancelSession(sessionId);
-      } catch (err) {
-        console.error(`[acp] Failed to cancel turn for session ${sessionId}:`, err);
+    try {
+      // Cancel before answering: the spec treats `cancelled` as the answer a
+      // client gives *because* it cancelled the turn, so settling first would
+      // leave the agent free to carry on and ask again. The wait is bounded and
+      // the settle happens either way — an agent wedged on its stdin must not
+      // hold waiting permissions, and their task-queue slots, open forever.
+      if (this.cancelSession) {
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        try {
+          await Promise.race([
+            Promise.resolve(this.cancelSession(sessionId)),
+            new Promise<void>((resolve) => {
+              timer = setTimeout(() => {
+                console.error(
+                  `[acp] session/cancel for ${sessionId} did not complete in ` +
+                    `${CANCEL_SESSION_TIMEOUT_MS}ms — settling permissions anyway`,
+                );
+                resolve();
+              }, CANCEL_SESSION_TIMEOUT_MS);
+            }),
+          ]);
+        } finally {
+          if (timer) clearTimeout(timer);
+        }
       }
+    } catch (err) {
+      console.error(`[acp] Failed to cancel turn for session ${sessionId}:`, err);
+    } finally {
+      this.cancelPendingPermissions("task cancelled", sessionId);
     }
-    this.cancelPendingPermissions("task cancelled", sessionId);
   }
 
   async flushReply(sessionId: string): Promise<void> {

--- a/src/acpClient.ts
+++ b/src/acpClient.ts
@@ -104,12 +104,20 @@ export class AgentRQACPClient implements acp.Client {
    * Used when the agent is gone: nothing will ever act on those answers, but
    * the promises must settle or their task-queue slots are held forever.
    */
-  cancelPendingPermissions(reason: string): void {
+  cancelPendingPermissions(reason: string, sessionId?: string): void {
     if (this.pendingPermissions.size === 0) return;
+    const toCancel = sessionId
+      ? [...this.pendingPermissions.values()].filter(
+          (p) => !p.sessionId || p.sessionId === sessionId,
+        )
+      : [...this.pendingPermissions.values()];
+
+    if (toCancel.length === 0) return;
+
     console.error(
-      `[acp] Cancelling ${this.pendingPermissions.size} waiting permission request(s): ${reason}`,
+      `[acp] Cancelling ${toCancel.length} waiting permission request(s): ${reason}`,
     );
-    for (const pending of [...this.pendingPermissions.values()]) {
+    for (const pending of toCancel) {
       pending.settle({ outcome: "cancelled" });
     }
   }
@@ -152,9 +160,11 @@ export class AgentRQACPClient implements acp.Client {
     pending.settle(this.outcomeForVerdict(pending.options, data.behavior));
   };
 
-  /** Stops the agent's current turn, where there is a connection to stop it on. */
-  private async cancelTurn(sessionId: string | undefined): Promise<void> {
-    if (!sessionId || !this.cancelSession) return;
+  /** Stops the agent's current turn and cancels any pending permissions for the session. */
+  async cancelTurn(sessionId: string | undefined): Promise<void> {
+    if (!sessionId) return;
+    this.cancelPendingPermissions("task cancelled", sessionId);
+    if (!this.cancelSession) return;
     try {
       await this.cancelSession(sessionId);
     } catch (err) {
@@ -300,7 +310,10 @@ export class AgentRQACPClient implements acp.Client {
             }, this.permissionTimeoutMs)
           : undefined;
 
+      let settled = false;
       const settle = (outcome: acp.RequestPermissionOutcome): void => {
+        if (settled) return;
+        settled = true;
         if (timer) clearTimeout(timer);
         this.pendingPermissions.delete(requestId);
         console.error(

--- a/src/acpClient.ts
+++ b/src/acpClient.ts
@@ -108,7 +108,7 @@ export class AgentRQACPClient implements acp.Client {
     if (this.pendingPermissions.size === 0) return;
     const toCancel = sessionId
       ? [...this.pendingPermissions.values()].filter(
-          (p) => !p.sessionId || p.sessionId === sessionId,
+          (p) => p.sessionId === sessionId,
         )
       : [...this.pendingPermissions.values()];
 
@@ -163,13 +163,14 @@ export class AgentRQACPClient implements acp.Client {
   /** Stops the agent's current turn and cancels any pending permissions for the session. */
   async cancelTurn(sessionId: string | undefined): Promise<void> {
     if (!sessionId) return;
-    this.cancelPendingPermissions("task cancelled", sessionId);
-    if (!this.cancelSession) return;
-    try {
-      await this.cancelSession(sessionId);
-    } catch (err) {
-      console.error(`[acp] Failed to cancel turn for session ${sessionId}:`, err);
+    if (this.cancelSession) {
+      try {
+        await this.cancelSession(sessionId);
+      } catch (err) {
+        console.error(`[acp] Failed to cancel turn for session ${sessionId}:`, err);
+      }
     }
+    this.cancelPendingPermissions("task cancelled", sessionId);
   }
 
   async flushReply(sessionId: string): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -323,6 +323,55 @@ export async function getOrCreateSession(
   return sessionInfo;
 }
 
+/**
+ * Finds the active agent session for a given task ID (or returns the single active session if none specified).
+ */
+export function findActiveSession(taskId?: string): AgentSession | undefined {
+  if (taskId) {
+    const direct = activeSessions.get(taskId);
+    if (direct) return direct;
+    for (const session of activeSessions.values()) {
+      if (session.sessionId === taskId) return session;
+    }
+  }
+  if (!taskId && activeSessions.size === 1) {
+    return activeSessions.values().next().value;
+  }
+  return undefined;
+}
+
+/**
+ * Handles task cancellation events from the MCP server.
+ * Cancels the ACP session/turn and immediately cancels any pending permissions.
+ */
+export async function handleTaskCancellation(
+  taskId?: string,
+  reason?: string,
+): Promise<void> {
+  if (taskId) {
+    lastTaskContent.delete(taskId);
+    const session = findActiveSession(taskId);
+    if (!session) {
+      console.error(
+        `[bridge] Received cancellation for task ${taskId}, but no active session found`,
+      );
+      return;
+    }
+    console.error(
+      `[bridge] Cancelling session ${session.sessionId} for task ${taskId}${reason ? ` (${reason})` : ""}`,
+    );
+    await session.acpClient.cancelTurn(session.sessionId);
+  } else {
+    console.error(
+      `[bridge] Received cancellation with no taskId${reason ? ` (${reason})` : ""}, cancelling all active sessions`,
+    );
+    for (const session of activeSessions.values()) {
+      await session.acpClient.cancelTurn(session.sessionId);
+    }
+  }
+}
+
+
 type AcpNewSessionParams = Parameters<
   acp.ClientSideConnection["newSession"]
 >[0];
@@ -1005,6 +1054,13 @@ async function main() {
         }
       }).catch((err) => {
         console.error("[bridge] Error queuing task:", err);
+      });
+    });
+
+    // Listen for task cancellation events from the MCP bridge
+    mcpBridge.on("cancel", ({ taskId, reason }: { taskId?: string; reason?: string }) => {
+      handleTaskCancellation(taskId, reason).catch((err) => {
+        console.error("[bridge] Error handling task cancellation:", err);
       });
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,7 @@ import {
 } from "./taskIdentity.js";
 
 const lastTaskContent = new Map<string, string>();
+export const cancelledTaskIds = new Set<string>();
 
 export interface AgentSession {
   process: any;
@@ -333,8 +334,11 @@ export function findActiveSession(taskId?: string): AgentSession | undefined {
     for (const session of activeSessions.values()) {
       if (session.sessionId === taskId) return session;
     }
-  }
-  if (!taskId && activeSessions.size === 1) {
+    // If there is exactly one active session (e.g. keyed "default"), fall back to it
+    if (activeSessions.size === 1) {
+      return activeSessions.values().next().value;
+    }
+  } else if (activeSessions.size === 1) {
     return activeSessions.values().next().value;
   }
   return undefined;
@@ -349,11 +353,11 @@ export async function handleTaskCancellation(
   reason?: string,
 ): Promise<void> {
   if (taskId) {
-    lastTaskContent.delete(taskId);
+    cancelledTaskIds.add(taskId);
     const session = findActiveSession(taskId);
     if (!session) {
       console.error(
-        `[bridge] Received cancellation for task ${taskId}, but no active session found`,
+        `[bridge] Received cancellation for task ${taskId}, but no active session found (queued tasks will be skipped)`,
       );
       return;
     }
@@ -362,15 +366,19 @@ export async function handleTaskCancellation(
     );
     await session.acpClient.cancelTurn(session.sessionId);
   } else {
-    console.error(
-      `[bridge] Received cancellation with no taskId${reason ? ` (${reason})` : ""}, cancelling all active sessions`,
-    );
-    for (const session of activeSessions.values()) {
+    const session = findActiveSession(undefined);
+    if (session) {
+      console.error(
+        `[bridge] Received cancellation with no taskId${reason ? ` (${reason})` : ""}. Cancelling active session ${session.sessionId}...`,
+      );
       await session.acpClient.cancelTurn(session.sessionId);
+    } else {
+      console.error(
+        `[bridge] Received cancellation with no taskId${reason ? ` (${reason})` : ""}, but ${activeSessions.size} active sessions found (skipping to avoid aborting unrelated tasks)`,
+      );
     }
   }
 }
-
 
 type AcpNewSessionParams = Parameters<
   acp.ClientSideConnection["newSession"]
@@ -1028,6 +1036,13 @@ async function main() {
         "\n[bridge] Incoming task from MCP server. Forwarding to ACP agent...",
       );
       taskQueue.run(async () => {
+        if (taskId && cancelledTaskIds.has(taskId)) {
+          console.error(
+            `[bridge] Task ${taskId} was cancelled before execution started, skipping`,
+          );
+          cancelledTaskIds.delete(taskId);
+          return;
+        }
         try {
           const sessionInfo = await getOrCreateSession(
             taskId,
@@ -1036,6 +1051,14 @@ async function main() {
             agentrqConfig,
             mcpBridge,
           );
+          if (taskId && cancelledTaskIds.has(taskId)) {
+            console.error(
+              `[bridge] Task ${taskId} was cancelled during session setup, cancelling session`,
+            );
+            cancelledTaskIds.delete(taskId);
+            await sessionInfo.acpClient.cancelTurn(sessionInfo.sessionId);
+            return;
+          }
           const result = await sessionInfo.connection.prompt({
             sessionId: sessionInfo.sessionId,
             prompt: [{ type: "text", text: content }],
@@ -1134,6 +1157,13 @@ export async function checkForNextTask(
       );
 
       const runFn = async () => {
+        if (taskId && cancelledTaskIds.has(taskId)) {
+          console.error(
+            `[bridge] Task ${taskId} was cancelled before execution started, skipping`,
+          );
+          cancelledTaskIds.delete(taskId);
+          return;
+        }
         let connectionToUse: acp.ClientSideConnection | undefined;
         let acpClientToUse: AgentRQACPClient | undefined;
         let sessionIdToUse: string | undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,46 @@ import {
 } from "./taskIdentity.js";
 
 const lastTaskContent = new Map<string, string>();
-export const cancelledTaskIds = new Set<string>();
+
+// Cancellations are remembered by *where they fall in the stream of events*
+// rather than as a one-shot flag. agentrq reuses a chat's id as the task id, so
+// a flag that outlived the cancellation it describes would swallow the user's
+// next message on that chat; ordered this way, a task is skipped only when the
+// cancel arrived after it was queued. Wall-clock time is too coarse to order
+// two events in the same millisecond, so this is a plain counter.
+let taskSeq = 0;
+export const nextTaskSeq = (): number => ++taskSeq;
+export const cancelledTaskSeq = new Map<string, number>();
+// A cancel for a task that never runs (a stale id, a task that already
+// finished) leaves an entry behind, so keep the map from growing without bound.
+const MAX_REMEMBERED_CANCELLATIONS = 200;
+
+/** Records that `taskId` has just been cancelled. */
+export function markTaskCancelled(taskId: string): void {
+  // Re-inserting moves the id to the end, so eviction stays oldest-first.
+  cancelledTaskSeq.delete(taskId);
+  cancelledTaskSeq.set(taskId, nextTaskSeq());
+  while (cancelledTaskSeq.size > MAX_REMEMBERED_CANCELLATIONS) {
+    const oldest = cancelledTaskSeq.keys().next().value as string;
+    cancelledTaskSeq.delete(oldest);
+  }
+}
+
+/**
+ * Whether a task queued at `queuedSeq` has since been cancelled.
+ *
+ * Two notifications for the same task id can be queued at once, so the check is
+ * against the point each was queued: cancelling the older one must not stop the
+ * newer one from running.
+ */
+export function isTaskCancelled(
+  taskId: string | undefined,
+  queuedSeq: number,
+): boolean {
+  if (!taskId) return false;
+  const seq = cancelledTaskSeq.get(taskId);
+  return seq !== undefined && seq > queuedSeq;
+}
 
 export interface AgentSession {
   process: any;
@@ -334,9 +373,13 @@ export function findActiveSession(taskId?: string): AgentSession | undefined {
     for (const session of activeSessions.values()) {
       if (session.sessionId === taskId) return session;
     }
-    // If there is exactly one active session (e.g. keyed "default"), fall back to it
-    if (activeSessions.size === 1) {
-      return activeSessions.values().next().value;
+    // A session opened from a notification that carried no task id is keyed
+    // "default"; when it is the only one running, an id-carrying cancel can
+    // only have meant it. Never fall back to a session keyed under a
+    // *different* task id — that would abort an unrelated task.
+    const untracked = activeSessions.get("default");
+    if (untracked && activeSessions.size === 1) {
+      return untracked;
     }
   } else if (activeSessions.size === 1) {
     return activeSessions.values().next().value;
@@ -353,7 +396,7 @@ export async function handleTaskCancellation(
   reason?: string,
 ): Promise<void> {
   if (taskId) {
-    cancelledTaskIds.add(taskId);
+    markTaskCancelled(taskId);
     const session = findActiveSession(taskId);
     if (!session) {
       console.error(
@@ -374,7 +417,10 @@ export async function handleTaskCancellation(
       await session.acpClient.cancelTurn(session.sessionId);
     } else {
       console.error(
-        `[bridge] Received cancellation with no taskId${reason ? ` (${reason})` : ""}, but ${activeSessions.size} active sessions found (skipping to avoid aborting unrelated tasks)`,
+        `[bridge] Received cancellation with no taskId${reason ? ` (${reason})` : ""}` +
+          (activeSessions.size === 0
+            ? ", and no sessions are active"
+            : `, but ${activeSessions.size} sessions are active (skipping to avoid aborting unrelated tasks)`),
       );
     }
   }
@@ -1035,12 +1081,12 @@ async function main() {
       console.error(
         "\n[bridge] Incoming task from MCP server. Forwarding to ACP agent...",
       );
+      const queuedSeq = nextTaskSeq();
       taskQueue.run(async () => {
-        if (taskId && cancelledTaskIds.has(taskId)) {
+        if (isTaskCancelled(taskId, queuedSeq)) {
           console.error(
             `[bridge] Task ${taskId} was cancelled before execution started, skipping`,
           );
-          cancelledTaskIds.delete(taskId);
           return;
         }
         try {
@@ -1051,11 +1097,10 @@ async function main() {
             agentrqConfig,
             mcpBridge,
           );
-          if (taskId && cancelledTaskIds.has(taskId)) {
+          if (isTaskCancelled(taskId, queuedSeq)) {
             console.error(
               `[bridge] Task ${taskId} was cancelled during session setup, cancelling session`,
             );
-            cancelledTaskIds.delete(taskId);
             await sessionInfo.acpClient.cancelTurn(sessionInfo.sessionId);
             return;
           }
@@ -1125,6 +1170,9 @@ export async function checkForNextTask(
   agentrqConfig?: McpServerConfig,
 ) {
   console.error("[bridge] Checking for next task via MCP server...");
+  // Stamped before the fetch, so a cancel that arrives while `getTask` is in
+  // flight (or while the session is being opened) still stops the task.
+  const queuedSeq = nextTaskSeq();
   try {
     const result = await mcpBridge.callTool("getTask");
 
@@ -1157,11 +1205,10 @@ export async function checkForNextTask(
       );
 
       const runFn = async () => {
-        if (taskId && cancelledTaskIds.has(taskId)) {
+        if (isTaskCancelled(taskId, queuedSeq)) {
           console.error(
             `[bridge] Task ${taskId} was cancelled before execution started, skipping`,
           );
-          cancelledTaskIds.delete(taskId);
           return;
         }
         let connectionToUse: acp.ClientSideConnection | undefined;
@@ -1199,6 +1246,17 @@ export async function checkForNextTask(
           connectionToUse = sessionInfo.connection;
           sessionIdToUse = sessionInfo.sessionId;
           acpClientToUse = sessionInfo.acpClient;
+        }
+
+        // Spawning the agent and opening the session takes seconds; a cancel
+        // that lands in that window has no turn to stop yet, so check again
+        // before handing the agent the work.
+        if (isTaskCancelled(taskId, queuedSeq)) {
+          console.error(
+            `[bridge] Task ${taskId} was cancelled during session setup, cancelling session`,
+          );
+          await acpClientToUse?.cancelTurn(sessionIdToUse);
+          return;
         }
 
         const promptResult = await connectionToUse.prompt({

--- a/src/mcpClient.ts
+++ b/src/mcpClient.ts
@@ -10,6 +10,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { EventEmitter } from "node:events";
 import { z } from "zod";
 import type { McpServerConfig } from "./config.js";
+import { extractTaskIdFromMeta } from "./taskIdentity.js";
 
 export class MCPBridge extends EventEmitter {
   private client: Client | null = null;
@@ -156,6 +157,32 @@ export class MCPBridge extends EventEmitter {
         console.error("[mcp] Received permission verdict");
         const { request_id, behavior } = notification.params;
         this.emit("verdict", { requestId: request_id, behavior });
+      },
+    );
+    // Set notification handler for task cancellation
+    this.client.setNotificationHandler(
+      z.object({
+        method: z.literal("notifications/claude/channel/cancel"),
+        params: z
+          .object({
+            task_id: z.string().optional(),
+            taskId: z.string().optional(),
+            chat_id: z.string().optional(),
+            reason: z.string().optional(),
+            meta: z.any().optional(),
+          })
+          .passthrough()
+          .optional(),
+      }),
+      (notification) => {
+        console.error("[mcp] Received task cancellation notification");
+        const params = notification.params ?? {};
+        const taskId =
+          params.task_id ||
+          params.taskId ||
+          params.chat_id ||
+          extractTaskIdFromMeta(params.meta);
+        this.emit("cancel", { taskId, reason: params.reason });
       },
     );
   }

--- a/src/mcpClient.ts
+++ b/src/mcpClient.ts
@@ -170,6 +170,7 @@ export class MCPBridge extends EventEmitter {
             chat_id: z.string().optional(),
             reason: z.string().optional(),
             meta: z.any().optional(),
+            _meta: z.any().optional(),
           })
           .passthrough()
           .optional(),
@@ -181,7 +182,8 @@ export class MCPBridge extends EventEmitter {
           params.task_id ||
           params.taskId ||
           params.chat_id ||
-          extractTaskIdFromMeta(params.meta);
+          extractTaskIdFromMeta(params.meta) ||
+          extractTaskIdFromMeta(params._meta);
         this.emit("cancel", { taskId, reason: params.reason });
       },
     );


### PR DESCRIPTION
### Summary of Changes

Task ID: `0i7xRDRmfdR`

1. **MCP Bridge Notification Handler**:
   - Added notification handler for `notifications/claude/channel/cancel` in [`src/mcpClient.ts`](file:///private/var/dev/Code/mt/go/src/github.com/agentrq/acp-gateway/src/mcpClient.ts).
   - Extracts `taskId` from `task_id`, `taskId`, `chat_id`, or `meta` payload, and emits a `"cancel"` event with `{ taskId, reason }`.

2. **Immediate Pending Permission Cancellation**:
   - Updated [`AgentRQACPClient.cancelPendingPermissions`](file:///private/var/dev/Code/mt/go/src/github.com/agentrq/acp-gateway/src/acpClient.ts) to support session-scoped cancellation, immediately resolving pending requests with `{ outcome: 'cancelled' }`.
   - Updated `cancelTurn(sessionId)` to immediately cancel pending permissions for the session and trigger `connection.cancel({ sessionId })`.

3. **Gateway Orchestration**:
   - Added `handleTaskCancellation` and `findActiveSession` in [`src/index.ts`](file:///private/var/dev/Code/mt/go/src/github.com/agentrq/acp-gateway/src/index.ts).
   - Wired `mcpBridge.on("cancel", ...)` in the main bridge loop to find active sessions and cancel turns cleanly.

4. **Tests**:
   - Added unit tests in `mcpClient.test.ts`, `acpClient.test.ts`, and `index.test.ts` verifying cancellation event handling, session-scoped pending permission cancellation, and error/edge cases.