### PR TITLE
feat(telemetry): forward agent reasoning, plans and usage to the workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ acp-gateway/
 │   ├── index.ts           # Entry point & orchestrator
 │   ├── mcpClient.ts       # MCP Bridge with auto-reconnect
 │   ├── registry.ts        # ACP registry index client
+│   ├── telemetry.ts       # Thought / plan / usage rendering
 │   └── __tests__/         # Unit tests
 ├── package.json
 └── tsconfig.json
@@ -262,6 +263,7 @@ acp-gateway/
 - **Auto-reconnection**: The MCP transport auto-reconnects on disconnection with exponential backoff (1s → 30s max).
 - **Notification-driven tasks**: The MCP server pushes task content via `notifications/claude/channel`; `acp-gateway` reacts immediately.
 - **Permission flow**: ACP agent requests permission → `acp-gateway` forwards to MCP server → waits for verdict → resolves the ACP permission.
+- **Streaming telemetry**: Reasoning, execution plans and token/cost counters are forwarded on `notifications/claude/channel/telemetry`. Reasoning is batched into one block per boundary (the agent starts answering, calls a tool, or revises its plan) rather than one message per token; plans go out as they change; only the last usage snapshot of a turn is reported. Sends are queued off the ACP stream, so a workspace that is slow or unreachable never stalls the agent.
 - **Registry agents**: `--agent <id>` resolves through the registry index; package distributions are preferred over binaries, and a binary without a published `sha256` is refused unless explicitly allowed.
 - **Authentication**: Login methods come from the `initialize` handshake; an `auth_required` refusal triggers a login and one retry of `newSession`.
 - **File I/O**: `readTextFile` / `writeTextFile` are proxied directly to the filesystem; paths are resolved relative to `process.cwd()`.

--- a/src/__tests__/acpClient.test.ts
+++ b/src/__tests__/acpClient.test.ts
@@ -1385,4 +1385,419 @@ describe("AgentRQACPClient", () => {
       ).rejects.toThrow("write failed");
     });
   });
+  describe("streaming telemetry", () => {
+    /** Every telemetry notification the bridge was asked to send, in order. */
+    function telemetrySent() {
+      return mcpBridge.sendNotification.mock.calls
+        .filter((c: any[]) => c[0] === "notifications/claude/channel/telemetry")
+        .map((c: any[]) => c[1]);
+    }
+
+    function newClient(taskId = "task-123") {
+      mcpBridge.callTool = vi
+        .fn()
+        .mockResolvedValue({ isError: false, content: [] });
+      vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+      return new AgentRQACPClient(
+        mcpBridge as unknown as MCPBridge,
+        () => taskId,
+      );
+    }
+
+    function thought(text: string) {
+      return {
+        sessionId: "sess-1",
+        update: {
+          sessionUpdate: "agent_thought_chunk",
+          content: { type: "text", text },
+        },
+      } as any;
+    }
+
+    it("batches thought chunks into one block per boundary", async () => {
+      const c = newClient();
+
+      await c.sessionUpdate(thought("Let me "));
+      await c.sessionUpdate(thought("check the config."));
+      // Nothing goes out mid-block: one notification per token is unusable.
+      expect(telemetrySent()).toHaveLength(0);
+
+      await c.sessionUpdate({
+        sessionId: "sess-1",
+        update: {
+          sessionUpdate: "tool_call",
+          title: "read_file",
+          status: "pending",
+          toolCallId: "tc-1",
+        },
+      } as any);
+      await c.flushReply("sess-1");
+
+      const thoughts = telemetrySent().filter((p: any) => p.kind === "thought");
+      expect(thoughts).toHaveLength(1);
+      expect(thoughts[0]).toMatchObject({
+        task_id: "task-123",
+        session_id: "sess-1",
+        kind: "thought",
+        text: "Let me check the config.",
+      });
+    });
+
+    it("closes off a reasoning block when the agent starts answering", async () => {
+      const c = newClient();
+
+      await c.sessionUpdate(thought("Thinking first."));
+      await c.sessionUpdate({
+        sessionId: "sess-1",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "The answer." },
+        },
+      } as any);
+      await c.sessionUpdate(thought("Second thought."));
+      await c.flushReply("sess-1");
+
+      expect(
+        telemetrySent()
+          .filter((p: any) => p.kind === "thought")
+          .map((p: any) => p.text),
+      ).toEqual(["Thinking first.", "Second thought."]);
+    });
+
+    it("keeps reasoning out of the reply the human sees", async () => {
+      const c = newClient();
+
+      await c.sessionUpdate(thought("Internal reasoning."));
+      await c.sessionUpdate({
+        sessionId: "sess-1",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "Done." },
+        },
+      } as any);
+      await c.flushReply("sess-1");
+
+      expect(mcpBridge.callTool).toHaveBeenCalledWith("reply", {
+        chatId: "task-123",
+        text: "Done.",
+      });
+    });
+
+    it("ignores non-text thought chunks", async () => {
+      const c = newClient();
+
+      await c.sessionUpdate({
+        sessionId: "sess-1",
+        update: {
+          sessionUpdate: "agent_thought_chunk",
+          content: { type: "image", data: "…" },
+        },
+      } as any);
+      await c.flushReply("sess-1");
+
+      expect(telemetrySent()).toHaveLength(0);
+    });
+
+    it("does not report whitespace-only reasoning", async () => {
+      const c = newClient();
+
+      await c.sessionUpdate(thought("   \n  "));
+      await c.flushReply("sess-1");
+
+      expect(telemetrySent()).toHaveLength(0);
+    });
+
+    it("reports a legacy plan update as soon as it arrives", async () => {
+      const c = newClient();
+
+      await c.sessionUpdate({
+        sessionId: "sess-1",
+        update: {
+          sessionUpdate: "plan",
+          entries: [
+            { content: "Read the config", priority: "high", status: "completed" },
+            { content: "Add tests", priority: "low", status: "pending" },
+          ],
+        },
+      } as any);
+      // Plans are queued, not awaited on the stream's hot path.
+      await c.flushReply("sess-1");
+
+      expect(telemetrySent()).toEqual([
+        {
+          task_id: "task-123",
+          session_id: "sess-1",
+          kind: "plan",
+          text: "- ✅ Read the config\n- ⬜ Add tests",
+          data: {
+            planId: "default",
+            planType: "items",
+            entries: [
+              {
+                content: "Read the config",
+                priority: "high",
+                status: "completed",
+              },
+              { content: "Add tests", priority: "low", status: "pending" },
+            ],
+          },
+        },
+      ]);
+    });
+
+    it("reports an ID-keyed plan update", async () => {
+      const c = newClient();
+
+      await c.sessionUpdate({
+        sessionId: "sess-1",
+        update: {
+          sessionUpdate: "plan_update",
+          plan: {
+            type: "markdown",
+            planId: "plan-7",
+            content: "## Steps\n1. Ship it",
+          },
+        },
+      } as any);
+      await c.flushReply("sess-1");
+
+      expect(telemetrySent()[0]).toMatchObject({
+        kind: "plan",
+        text: "## Steps\n1. Ship it",
+        data: {
+          planId: "plan-7",
+          planType: "markdown",
+          content: "## Steps\n1. Ship it",
+        },
+      });
+    });
+
+    it("reports a withdrawn plan so the human sees it was dropped", async () => {
+      const c = newClient();
+
+      await c.sessionUpdate({
+        sessionId: "sess-1",
+        update: { sessionUpdate: "plan_removed", planId: "plan-7" },
+      } as any);
+      await c.flushReply("sess-1");
+
+      expect(telemetrySent()[0]).toMatchObject({
+        kind: "plan",
+        text: "Plan withdrawn.",
+        data: { planId: "plan-7", removed: true },
+      });
+    });
+
+    it("puts reasoning in front of the plan it explains", async () => {
+      const c = newClient();
+
+      await c.sessionUpdate(thought("I should plan this out."));
+      await c.sessionUpdate({
+        sessionId: "sess-1",
+        update: { sessionUpdate: "plan", entries: [] },
+      } as any);
+      await c.sessionUpdate({
+        sessionId: "sess-1",
+        update: { sessionUpdate: "plan_removed", planId: "default" },
+      } as any);
+      await c.flushReply("sess-1");
+
+      expect(telemetrySent().map((p: any) => p.kind)).toEqual([
+        "thought",
+        "plan",
+        "plan",
+      ]);
+    });
+
+    it("reports only the last usage snapshot, once the turn is over", async () => {
+      const c = newClient();
+
+      await c.sessionUpdate({
+        sessionId: "sess-1",
+        update: { sessionUpdate: "usage_update", used: 100, size: 200_000 },
+      } as any);
+      await c.sessionUpdate({
+        sessionId: "sess-1",
+        update: {
+          sessionUpdate: "usage_update",
+          used: 50_000,
+          size: 200_000,
+          cost: { amount: 0.42, currency: "USD" },
+        },
+      } as any);
+      // Each snapshot supersedes the last, so none go out mid-turn.
+      expect(telemetrySent()).toHaveLength(0);
+
+      await c.flushReply("sess-1");
+
+      expect(telemetrySent()).toEqual([
+        {
+          task_id: "task-123",
+          session_id: "sess-1",
+          kind: "usage",
+          text: "Context 50,000 / 200,000 tokens (25%) · 0.42 USD",
+          data: {
+            used: 50_000,
+            size: 200_000,
+            percent: 25,
+            cost: { amount: 0.42, currency: "USD" },
+          },
+        },
+      ]);
+    });
+
+    it("does not report the same usage snapshot on a later turn", async () => {
+      const c = newClient();
+
+      await c.sessionUpdate({
+        sessionId: "sess-1",
+        update: { sessionUpdate: "usage_update", used: 100, size: 200_000 },
+      } as any);
+      await c.flushReply("sess-1");
+      mcpBridge.sendNotification.mockClear();
+
+      await c.flushReply("sess-1");
+      expect(telemetrySent()).toHaveLength(0);
+    });
+
+    it("orders reasoning, the reply, then the usage footer", async () => {
+      const c = newClient();
+      const order: string[] = [];
+      mcpBridge.sendNotification = vi.fn(async (_m: string, p: any) => {
+        order.push(p.kind);
+      });
+      mcpBridge.callTool = vi.fn(async () => {
+        order.push("reply");
+        return { isError: false, content: [] };
+      });
+
+      await c.sessionUpdate(thought("Reasoning."));
+      await c.sessionUpdate({
+        sessionId: "sess-1",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "Answer." },
+        },
+      } as any);
+      await c.sessionUpdate({
+        sessionId: "sess-1",
+        update: { sessionUpdate: "usage_update", used: 1, size: 100 },
+      } as any);
+      await c.flushReply("sess-1");
+
+      expect(order).toEqual(["thought", "reply", "usage"]);
+    });
+
+    it("drops telemetry when the session has no task to attach it to", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const c = new AgentRQACPClient(
+        mcpBridge as unknown as MCPBridge,
+        () => undefined,
+      );
+
+      await c.sessionUpdate(thought("Nowhere to put this."));
+      await c.flushReply("sess-1");
+
+      expect(telemetrySent()).toHaveLength(0);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("dropping thought telemetry"),
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it("still delivers the reply when telemetry cannot be sent", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const c = newClient();
+      mcpBridge.sendNotification.mockRejectedValue(new Error("offline"));
+
+      await c.sessionUpdate(thought("Reasoning."));
+      await c.sessionUpdate({
+        sessionId: "sess-1",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "Answer." },
+        },
+      } as any);
+      await c.flushReply("sess-1");
+
+      expect(mcpBridge.callTool).toHaveBeenCalledWith("reply", {
+        chatId: "task-123",
+        text: "Answer.",
+      });
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to send thought telemetry"),
+        expect.anything(),
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it("keeps sending telemetry after one send has failed", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const c = newClient();
+      mcpBridge.sendNotification
+        .mockRejectedValueOnce(new Error("offline"))
+        .mockResolvedValue(undefined);
+
+      await c.sessionUpdate(thought("First block."));
+      await c.sessionUpdate({
+        sessionId: "sess-1",
+        update: {
+          sessionUpdate: "tool_call",
+          title: "read_file",
+          status: "pending",
+          toolCallId: "tc-1",
+        },
+      } as any);
+      await c.sessionUpdate(thought("Second block."));
+      await c.flushReply("sess-1");
+
+      expect(telemetrySent().map((p: any) => p.text)).toEqual([
+        "First block.",
+        "Second block.",
+      ]);
+      consoleSpy.mockRestore();
+    });
+
+    it("survives a queued send that throws outright", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      // Looking up the task is the gateway's own callback, and it is the one
+      // step outside sendTelemetry's own error handling.
+      const c = new AgentRQACPClient(mcpBridge as unknown as MCPBridge, () => {
+        throw new Error("task lookup blew up");
+      });
+
+      await c.sessionUpdate(thought("Reasoning."));
+      await expect(c.flushReply("sess-1")).resolves.toBeUndefined();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Telemetry send failed"),
+        expect.anything(),
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it("keeps each session's telemetry to itself", async () => {
+      const c = new AgentRQACPClient(
+        mcpBridge as unknown as MCPBridge,
+        (sessionId: string) => `task-${sessionId}`,
+      );
+
+      await c.sessionUpdate(thought("Session one."));
+      await c.sessionUpdate({
+        sessionId: "sess-2",
+        update: {
+          sessionUpdate: "agent_thought_chunk",
+          content: { type: "text", text: "Session two." },
+        },
+      } as any);
+      await c.flushReply("sess-2");
+
+      expect(telemetrySent()).toHaveLength(1);
+      expect(telemetrySent()[0]).toMatchObject({
+        task_id: "task-sess-2",
+        text: "Session two.",
+      });
+    });
+  });
+
 });

--- a/src/__tests__/telemetry.test.ts
+++ b/src/__tests__/telemetry.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_PLAN_ID,
+  TELEMETRY_NOTIFICATION_METHOD,
+  contextPercent,
+  formatPlan,
+  formatUsage,
+  planFromEntries,
+  planTelemetryData,
+  usageTelemetryData,
+  type NormalizedPlan,
+} from "../telemetry.js";
+
+describe("telemetry", () => {
+  it("sends on the same channel as the other gateway notifications", () => {
+    expect(TELEMETRY_NOTIFICATION_METHOD).toBe(
+      "notifications/claude/channel/telemetry",
+    );
+  });
+
+  describe("planFromEntries", () => {
+    it("gives a legacy plan update the same shape as an ID-keyed one", () => {
+      const plan = planFromEntries([
+        { content: "Read the config", priority: "high", status: "completed" },
+      ]);
+      expect(plan).toEqual({
+        planId: DEFAULT_PLAN_ID,
+        type: "items",
+        entries: [
+          { content: "Read the config", priority: "high", status: "completed" },
+        ],
+      });
+    });
+  });
+
+  describe("formatPlan", () => {
+    it("renders each entry with a marker for its status", () => {
+      const plan = planFromEntries([
+        { content: "Read the config", priority: "high", status: "completed" },
+        { content: "Wire the channel", priority: "medium", status: "in_progress" },
+        { content: "Add tests", priority: "low", status: "pending" },
+      ]);
+      expect(formatPlan(plan)).toBe(
+        "- ✅ Read the config\n- 🔄 Wire the channel\n- ⬜ Add tests",
+      );
+    });
+
+    it("falls back to the pending marker for a status it does not know", () => {
+      const plan = planFromEntries([
+        { content: "Something new", priority: "low", status: "blocked" as any },
+      ]);
+      expect(formatPlan(plan)).toBe("- ⬜ Something new");
+    });
+
+    it("renders an empty plan as empty text", () => {
+      expect(formatPlan(planFromEntries([]))).toBe("");
+    });
+
+    it("renders a file-backed plan as its URI", () => {
+      const plan: NormalizedPlan = {
+        planId: "p1",
+        type: "file",
+        uri: "file:///tmp/plan.md",
+      };
+      expect(formatPlan(plan)).toBe("Plan: file:///tmp/plan.md");
+    });
+
+    it("passes a markdown plan through unchanged", () => {
+      const plan: NormalizedPlan = {
+        planId: "p1",
+        type: "markdown",
+        content: "## Steps\n1. Do it",
+      };
+      expect(formatPlan(plan)).toBe("## Steps\n1. Do it");
+    });
+  });
+
+  describe("planTelemetryData", () => {
+    it("keeps the fields a client renders and drops ACP's _meta", () => {
+      const plan = planFromEntries([
+        {
+          content: "Read the config",
+          priority: "high",
+          status: "completed",
+          _meta: { internal: true },
+        },
+      ]);
+      expect(planTelemetryData(plan)).toEqual({
+        planId: DEFAULT_PLAN_ID,
+        planType: "items",
+        entries: [
+          { content: "Read the config", priority: "high", status: "completed" },
+        ],
+      });
+    });
+
+    it("carries the URI of a file-backed plan", () => {
+      expect(
+        planTelemetryData({
+          planId: "p1",
+          type: "file",
+          uri: "file:///tmp/plan.md",
+        }),
+      ).toEqual({ planId: "p1", planType: "file", uri: "file:///tmp/plan.md" });
+    });
+
+    it("carries the body of a markdown plan", () => {
+      expect(
+        planTelemetryData({ planId: "p1", type: "markdown", content: "# Plan" }),
+      ).toEqual({ planId: "p1", planType: "markdown", content: "# Plan" });
+    });
+  });
+
+  describe("contextPercent", () => {
+    it("reports how much of the context window is in use", () => {
+      expect(contextPercent({ used: 50_000, size: 200_000 })).toBe(25);
+    });
+
+    it("is unknowable when the agent reports no window size", () => {
+      expect(contextPercent({ used: 10, size: 0 })).toBeUndefined();
+      expect(contextPercent({ used: 10, size: -1 })).toBeUndefined();
+    });
+  });
+
+  describe("formatUsage", () => {
+    it("renders counts with separators and a percentage", () => {
+      expect(formatUsage({ used: 12_345, size: 200_000 })).toBe(
+        "Context 12,345 / 200,000 tokens (6%)",
+      );
+    });
+
+    it("omits the percentage when there is no window size to divide by", () => {
+      expect(formatUsage({ used: 12_345, size: 0 })).toBe(
+        "Context 12,345 / 0 tokens",
+      );
+    });
+
+    it("appends the cost when the agent reports one", () => {
+      expect(
+        formatUsage({
+          used: 1_000,
+          size: 200_000,
+          cost: { amount: 0.42, currency: "USD" },
+        }),
+      ).toBe("Context 1,000 / 200,000 tokens (1%) · 0.42 USD");
+    });
+
+    it("keeps sub-cent costs from rounding away to nothing", () => {
+      expect(
+        formatUsage({
+          used: 1,
+          size: 100,
+          cost: { amount: 0.0023, currency: "USD" },
+        }),
+      ).toBe("Context 1 / 100 tokens (1%) · 0.0023 USD");
+    });
+
+    it("renders a zero cost plainly rather than at four decimals", () => {
+      expect(
+        formatUsage({
+          used: 1,
+          size: 100,
+          cost: { amount: 0, currency: "EUR" },
+        }),
+      ).toBe("Context 1 / 100 tokens (1%) · 0.00 EUR");
+    });
+  });
+
+  describe("usageTelemetryData", () => {
+    it("carries the counts and the percentage", () => {
+      expect(usageTelemetryData({ used: 50_000, size: 200_000 })).toEqual({
+        used: 50_000,
+        size: 200_000,
+        percent: 25,
+      });
+    });
+
+    it("omits the percentage when there is no window size", () => {
+      expect(usageTelemetryData({ used: 10, size: 0 })).toEqual({
+        used: 10,
+        size: 0,
+      });
+    });
+
+    it("keeps the cost and drops ACP's _meta", () => {
+      expect(
+        usageTelemetryData({
+          used: 10,
+          size: 100,
+          cost: { amount: 1.5, currency: "USD", _meta: { internal: true } },
+        }),
+      ).toEqual({
+        used: 10,
+        size: 100,
+        percent: 10,
+        cost: { amount: 1.5, currency: "USD" },
+      });
+    });
+  });
+});

--- a/src/acpClient.ts
+++ b/src/acpClient.ts
@@ -7,6 +7,17 @@
 
 import * as acp from "@agentclientprotocol/sdk";
 import type { MCPBridge } from "./mcpClient.js";
+import {
+  TELEMETRY_NOTIFICATION_METHOD,
+  formatPlan,
+  formatUsage,
+  planFromEntries,
+  planTelemetryData,
+  usageTelemetryData,
+  type NormalizedPlan,
+  type TelemetryKind,
+  type TelemetryPayload,
+} from "./telemetry.js";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
@@ -51,6 +62,18 @@ const STOP_REASON_NOTES: Record<string, string> = {
 
 export class AgentRQACPClient implements acp.Client {
   private replyBuffers = new Map<string, string>();
+  // sessionId → reasoning accumulated since the last boundary. Thought tokens
+  // stream one at a time and are deliberately kept out of replyBuffers: they
+  // are not the answer, and folding them in would both corrupt the reply and
+  // break the dedup against the agent's own `reply` tool call.
+  private thoughtBuffers = new Map<string, string>();
+  // sessionId → the most recent usage snapshot. Only the last one is worth
+  // reporting: each supersedes the one before it.
+  private latestUsage = new Map<string, acp.UsageUpdate>();
+  // Telemetry sends, run one after another so the workspace sees them in the
+  // order the agent produced them, and off the ACP stream's critical path so a
+  // slow or unreachable workspace never stalls the agent mid-turn.
+  private telemetryChain: Promise<void> = Promise.resolve();
   // chatId → text sent by the agent via the reply MCP tool (for dedup in flushReply)
   private agentReplies = new Map<string, string>();
   // toolCallId → details seen on session updates. A `tool_call` update always
@@ -198,7 +221,126 @@ export class AgentRQACPClient implements acp.Client {
     }
   }
 
+  /**
+   * Ends the turn: everything the agent produced besides its answer goes out
+   * around the answer itself.
+   *
+   * The reasoning that led to the answer has to precede it, and the token and
+   * cost counters read as a footer, so they follow.
+   */
   async flushReply(sessionId: string): Promise<void> {
+    await this.flushThought(sessionId);
+    await this.deliverReply(sessionId);
+    await this.flushUsage(sessionId);
+  }
+
+  /**
+   * Queues whatever reasoning has accumulated for sending, and waits for the
+   * telemetry queue to drain.
+   *
+   * Taking the buffer here rather than inside the queued send is what keeps a
+   * reasoning block whole: anything the agent thinks after this point belongs
+   * to the next block.
+   */
+  private async flushThought(sessionId: string): Promise<void> {
+    this.queueThoughtFlush(sessionId);
+    await this.telemetryChain;
+  }
+
+  /**
+   * Closes off the current reasoning block, if there is one.
+   *
+   * Called wherever the agent stops thinking and does something else — starts
+   * answering, calls a tool, revises its plan — so a block of reasoning
+   * reaches the human while it still explains what is about to happen, rather
+   * than arriving in one lump at the end of the turn.
+   */
+  private queueThoughtFlush(sessionId: string): void {
+    const thought = this.thoughtBuffers.get(sessionId);
+    if (!thought?.trim()) return;
+    this.thoughtBuffers.delete(sessionId);
+    this.queueTelemetry(() =>
+      this.sendTelemetry(sessionId, "thought", thought, {}),
+    );
+  }
+
+  /** Reports the last usage snapshot of the turn, if the agent sent any. */
+  private async flushUsage(sessionId: string): Promise<void> {
+    const usage = this.latestUsage.get(sessionId);
+    this.latestUsage.delete(sessionId);
+    if (!usage) return;
+    await this.sendTelemetry(
+      sessionId,
+      "usage",
+      formatUsage(usage),
+      usageTelemetryData(usage),
+    );
+  }
+
+  /** Reports a plan the agent has just published or revised. */
+  private queuePlan(sessionId: string, plan: NormalizedPlan): void {
+    this.queueThoughtFlush(sessionId);
+    this.queueTelemetry(() =>
+      this.sendTelemetry(
+        sessionId,
+        "plan",
+        formatPlan(plan),
+        planTelemetryData(plan),
+      ),
+    );
+  }
+
+  /** Adds a send to the tail of the telemetry queue. */
+  private queueTelemetry(send: () => Promise<void>): void {
+    this.telemetryChain = this.telemetryChain
+      .catch(() => {})
+      .then(send)
+      .catch((err) => {
+        console.error(`[acp] Telemetry send failed:`, err);
+      });
+  }
+
+  /**
+   * Forwards one piece of telemetry to the workspace.
+   *
+   * Never throws: telemetry is not the answer, so a workspace that cannot take
+   * it right now must not cost the agent its turn.
+   */
+  private async sendTelemetry(
+    sessionId: string,
+    kind: TelemetryKind,
+    text: string,
+    data: Record<string, unknown>,
+  ): Promise<void> {
+    const taskId = this.getTaskIdForSession(sessionId);
+    if (!taskId) {
+      console.error(
+        `[acp] No task ID for session ${sessionId}, dropping ${kind} telemetry`,
+      );
+      return;
+    }
+
+    const payload: TelemetryPayload = {
+      task_id: taskId,
+      session_id: sessionId,
+      kind,
+      text,
+      data,
+    };
+    try {
+      await this.mcpBridge.sendNotification(
+        TELEMETRY_NOTIFICATION_METHOD,
+        payload,
+      );
+    } catch (err) {
+      console.error(
+        `[acp] Failed to send ${kind} telemetry for session ${sessionId}:`,
+        err,
+      );
+    }
+  }
+
+  private async deliverReply(sessionId: string): Promise<void> {
     const text = this.replyBuffers.get(sessionId) ?? "";
     this.replyBuffers.delete(sessionId);
     if (!text.trim()) return;
@@ -443,10 +585,41 @@ export class AgentRQACPClient implements acp.Client {
     switch (update.sessionUpdate) {
       case "agent_message_chunk":
         if (update.content.type === "text") {
+          // The agent has stopped thinking and started answering.
+          this.queueThoughtFlush(params.sessionId);
           process.stdout.write(update.content.text);
           const sid = params.sessionId;
           this.replyBuffers.set(sid, (this.replyBuffers.get(sid) ?? "") + update.content.text);
         }
+        break;
+      case "agent_thought_chunk":
+        if (update.content.type === "text") {
+          const sid = params.sessionId;
+          this.thoughtBuffers.set(
+            sid,
+            (this.thoughtBuffers.get(sid) ?? "") + update.content.text,
+          );
+        }
+        break;
+      case "plan":
+        this.queuePlan(params.sessionId, planFromEntries(update.entries));
+        break;
+      case "plan_update":
+        this.queuePlan(params.sessionId, update.plan);
+        break;
+      case "plan_removed":
+        this.queueThoughtFlush(params.sessionId);
+        this.queueTelemetry(() =>
+          this.sendTelemetry(params.sessionId, "plan", "Plan withdrawn.", {
+            planId: update.planId,
+            removed: true,
+          }),
+        );
+        break;
+      case "usage_update":
+        // Each snapshot supersedes the last; only the final one is reported,
+        // at the end of the turn.
+        this.latestUsage.set(params.sessionId, update);
         break;
       case "current_mode_update":
         console.error(`[acp] Agent switched session mode to "${update.currentModeId}"`);
@@ -456,6 +629,8 @@ export class AgentRQACPClient implements acp.Client {
         this.rememberToolCall(update);
         break;
       case "tool_call": {
+        // Reasoning that explains a tool call belongs in front of it.
+        this.queueThoughtFlush(params.sessionId);
         this.rememberToolCall(update);
         if (update.title && AGENTRQ_TOOL_PATTERN.test(update.title)) {
           // Track completed reply calls so flushReply can skip exact duplicates

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,0 +1,147 @@
+/**
+ * telemetry.ts
+ *
+ * Renders the ACP session updates that carry no answer — the agent's
+ * reasoning, its execution plan, its token and cost counters — into something
+ * a human reading the workspace can act on.
+ *
+ * These updates used to be dropped on the floor, so the workspace saw the
+ * final answer and the tool calls and nothing of how the agent got there.
+ */
+
+import type * as acp from "@agentclientprotocol/sdk";
+
+/** The notification agentrq listens on for everything in this file. */
+export const TELEMETRY_NOTIFICATION_METHOD =
+  "notifications/claude/channel/telemetry";
+
+/** Which kind of telemetry a notification carries. */
+export type TelemetryKind = "thought" | "plan" | "usage";
+
+/**
+ * The wire shape agentrq receives. Keys are snake_case to match the sibling
+ * `permission_request` and `cancel` notifications on the same channel.
+ */
+export interface TelemetryPayload {
+  task_id: string;
+  session_id: string;
+  kind: TelemetryKind;
+  /** Ready to show as-is, for anything that cannot read `data`. */
+  text: string;
+  /** The same telemetry structured, for a client that renders it properly. */
+  data: Record<string, unknown>;
+}
+
+/**
+ * The plan id a legacy `plan` update refers to.
+ *
+ * `plan_update` carries an id so an agent can run several plans at once; the
+ * older `plan` update predates that and always means the session's single
+ * plan. Giving it a fixed id puts both through one path — and keeps an agent
+ * that sends both from opening a second plan alongside the first.
+ */
+export const DEFAULT_PLAN_ID = "default";
+
+/** A plan in the one shape the rest of the gateway deals with. */
+export type NormalizedPlan =
+  | { planId: string; type: "items"; entries: acp.PlanEntry[] }
+  | { planId: string; type: "file"; uri: string }
+  | { planId: string; type: "markdown"; content: string };
+
+/** How each plan entry status reads in the text fallback. */
+const PLAN_STATUS_MARKERS: Record<string, string> = {
+  completed: "✅",
+  in_progress: "🔄",
+  pending: "⬜",
+};
+
+/** Wraps the entries of a legacy `plan` update as a normal plan. */
+export function planFromEntries(entries: acp.PlanEntry[]): NormalizedPlan {
+  return { planId: DEFAULT_PLAN_ID, type: "items", entries };
+}
+
+/** Renders a plan as markdown, for clients that only show message text. */
+export function formatPlan(plan: NormalizedPlan): string {
+  switch (plan.type) {
+    case "items":
+      return plan.entries
+        .map(
+          (entry) =>
+            `- ${PLAN_STATUS_MARKERS[entry.status] ?? PLAN_STATUS_MARKERS.pending} ${entry.content}`,
+        )
+        .join("\n");
+    case "file":
+      return `Plan: ${plan.uri}`;
+    case "markdown":
+      return plan.content;
+  }
+}
+
+/** The structured form of a plan, with ACP's `_meta` left behind. */
+export function planTelemetryData(
+  plan: NormalizedPlan,
+): Record<string, unknown> {
+  const base = { planId: plan.planId, planType: plan.type };
+  switch (plan.type) {
+    case "items":
+      return {
+        ...base,
+        entries: plan.entries.map((entry) => ({
+          content: entry.content,
+          priority: entry.priority,
+          status: entry.status,
+        })),
+      };
+    case "file":
+      return { ...base, uri: plan.uri };
+    case "markdown":
+      return { ...base, content: plan.content };
+  }
+}
+
+/** Thousands-separated, so six-figure token counts stay readable. */
+function formatTokens(tokens: number): string {
+  return tokens.toLocaleString("en-US");
+}
+
+/**
+ * Renders a cost with enough precision to be worth showing. Agent turns
+ * routinely cost fractions of a cent, and `0.00 USD` says nothing.
+ */
+function formatCost(cost: acp.Cost): string {
+  const amount =
+    cost.amount !== 0 && Math.abs(cost.amount) < 0.01
+      ? cost.amount.toFixed(4)
+      : cost.amount.toFixed(2);
+  return `${amount} ${cost.currency}`;
+}
+
+/** How much of the context window is in use, or undefined if unknowable. */
+export function contextPercent(usage: acp.UsageUpdate): number | undefined {
+  if (usage.size <= 0) return undefined;
+  return Math.round((usage.used / usage.size) * 100);
+}
+
+/** Renders a usage snapshot as a single line, for clients that only show text. */
+export function formatUsage(usage: acp.UsageUpdate): string {
+  const percent = contextPercent(usage);
+  let context = `Context ${formatTokens(usage.used)} / ${formatTokens(usage.size)} tokens`;
+  if (percent !== undefined) context += ` (${percent}%)`;
+  return usage.cost ? `${context} · ${formatCost(usage.cost)}` : context;
+}
+
+/** The structured form of a usage snapshot, with ACP's `_meta` left behind. */
+export function usageTelemetryData(
+  usage: acp.UsageUpdate,
+): Record<string, unknown> {
+  const data: Record<string, unknown> = {
+    used: usage.used,
+    size: usage.size,
+  };
+  const percent = contextPercent(usage);
+  if (percent !== undefined) data.percent = percent;
+  if (usage.cost) {
+    data.cost = { amount: usage.cost.amount, currency: usage.cost.currency };
+  }
+  return data;
+}


### PR DESCRIPTION
## What changed

The gateway used to throw away everything an agent streamed except its answer and its tool calls — the reasoning behind the answer, the step-by-step plan it was working to, and how much context and money the turn was using all fell on the floor. All of it now reaches the workspace, batched so it reads as a conversation rather than a firehose: reasoning arrives as one block per thinking pass instead of one message per token, plans arrive as they change, and the token and cost counters are reported once at the end of a turn.

## Why

A person watching a task could see what the agent finally said and which tools it ran, but nothing about how it got there — no reasoning, no plan, no sense of what the turn was costing. That is most of what makes a long agent run followable, and the protocol was already sending it.

## Test coverage report

- **New lines: 100%.** `src/telemetry.ts` is at 100% statements / branches / functions / lines. Every line added to `src/acpClient.ts` is covered, including the failure paths.
- **Total coverage impact:** 88.69% → 88.78% statements, 88.54% → 88.64% lines, 86.82% → 87.31% functions. `acpClient.ts` rose from 98.29% to 98.91% lines; its three remaining uncovered lines all predate this change.
- Suite: 316 → 353 tests, all passing. `tsc --noEmit` clean.

## Other notes

- Reasoning is deliberately kept out of the reply buffer. It is not the answer, and folding it in would both corrupt the reply text and break the existing dedup against the agent's own `reply` tool call.
- Sends run on an ordered queue off the ACP stream's critical path, so a workspace that is slow or unreachable can never stall the agent mid-turn, and a failed send never costs the agent its turn.
- The legacy `plan` update and the newer ID-keyed `plan_update` are normalised to one shape, so an agent that emits both keeps revising a single plan rather than opening a second one alongside it.
- Requires the matching workspace change: agentrq/agentrq#398.

TaskID: 0i81xtB9kQr

---
Generated with [AgentRQ](https://agentrq.com)