### PR TITLE
chore: bump version to 0.2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install -g @agentrq/acp-gateway
 
 ## Current Version
 
-`0.2.5`
+`0.2.6`
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentrq/acp-gateway",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.4.0",
         "@modelcontextprotocol/sdk": "^1.30.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "ACP+MCP bridge CLI for agentrq workspaces",
   "type": "module",
   "publishConfig": {

--- a/src/mcpClient.ts
+++ b/src/mcpClient.ts
@@ -96,7 +96,7 @@ export class MCPBridge extends EventEmitter {
     this.client = new Client(
       {
         name: "acp-gateway",
-        version: "0.2.5",
+        version: "0.2.6",
       },
       {
         capabilities: {},


### PR DESCRIPTION
## What changed

Version bumped from 0.2.5 to 0.2.6, cutting a release that carries the streaming telemetry work: agent reasoning, execution plans and context/cost counters now reach the workspace instead of being dropped.

## Why

0.2.5 is already published, so the telemetry change needs a version of its own before it can go out.

## Test coverage report

- **New lines: 100%** — no new logic, only the version string in the four places that carry it (`package.json`, `package-lock.json`, `README.md`, and the MCP client identity in `src/mcpClient.ts`).
- **Total coverage impact:** none. 353 tests pass unchanged, `tsc --noEmit` clean.

## Other notes

- The MCP client announces this version to the workspace on connect, so leaving `src/mcpClient.ts` behind would have the gateway reporting itself as 0.2.5 in every session.

TaskID: 0i81xtB9kQr

---
Generated with [AgentRQ](https://agentrq.com)