### PR TITLE
chore: bump version to 0.2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install -g @agentrq/acp-gateway
 
 ## Current Version
 
-`0.2.6`
+`0.2.7`
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentrq/acp-gateway",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.4.0",
         "@modelcontextprotocol/sdk": "^1.30.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "ACP+MCP bridge CLI for agentrq workspaces",
   "type": "module",
   "publishConfig": {

--- a/src/mcpClient.ts
+++ b/src/mcpClient.ts
@@ -96,7 +96,7 @@ export class MCPBridge extends EventEmitter {
     this.client = new Client(
       {
         name: "acp-gateway",
-        version: "0.2.6",
+        version: "0.2.7",
       },
       {
         capabilities: {},


### PR DESCRIPTION
## What changed
Bumped package and client version from `0.2.6` to `0.2.7`.

## Why changed
Release version bump following the addition of clientInfo and plan capability declaration during the ACP initialization handshake.

## Test coverage report
- Total test suite: 356 passed, 0 failed

TaskID: 0i8DnZABNnV

---
Generated with [AgentRQ](https://agentrq.com)