### PR TITLE
chore: bump version to 0.2.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install -g @agentrq/acp-gateway
 
 ## Current Version
 
-`0.2.7`
+`0.2.8`
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentrq/acp-gateway",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.4.0",
         "@modelcontextprotocol/sdk": "^1.30.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "ACP+MCP bridge CLI for agentrq workspaces",
   "type": "module",
   "publishConfig": {

--- a/src/mcpClient.ts
+++ b/src/mcpClient.ts
@@ -96,7 +96,7 @@ export class MCPBridge extends EventEmitter {
     this.client = new Client(
       {
         name: "acp-gateway",
-        version: "0.2.7",
+        version: "0.2.8",
       },
       {
         capabilities: {},


### PR DESCRIPTION
### What changed
Bumped package patch version to 0.2.8.

### Why changed
Release patch version update following the session clean close functionality merge.

### Test coverage report
- New lines introduced: 100%
- Total coverage impact: 87.89% statement coverage, 87.74% line coverage across all files

TaskID: 0i8GKc3TtVR

Generated with [AgentRQ](https://agentrq.com)