### PR TITLE
feat: decrease default concurrency to 1 (TaskID: 0iEsG4arDyj)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ acp-gateway -- your-acp-agent --flag1 --flag2
 
 You can specify gateway options before the `--` separator:
 
-- `--max-concurrency` / `--maxConcurrency` `<number>`: Sets the maximum number of concurrent tasks allowed to prompt the ACP agent at once. Defaults to `2`.
+- `--max-concurrency` / `--maxConcurrency` `<number>`: Sets the maximum number of concurrent tasks allowed to prompt the ACP agent at once. Defaults to `1`.
 - `--agent <registry-id>`: Runs an agent from the ACP registry instead of a command you supply yourself.
 - `--list-agents`: Prints every agent in the registry and how each one can run on this machine, then exits.
 - `--list-models`: Prints the models supported by the agent, then exits.

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -14,6 +14,7 @@ import {
   createSessionWithAuth,
   isInteractiveTerminal,
   openAgentConnection,
+  DEFAULT_MAX_CONCURRENCY,
   parseGatewayArgs,
   assertAgentRunnable,
   helpText,
@@ -765,9 +766,9 @@ describe("index", () => {
   });
 
   describe("parseGatewayArgs", () => {
-    it("should default to bridging tasks with a concurrency of 2", () => {
+    it("should default to bridging tasks with a concurrency of 1", () => {
       expect(parseGatewayArgs([])).toEqual({
-        maxConcurrency: 2,
+        maxConcurrency: 1,
         permissionTimeoutMs: 30 * 60_000,
         command: "run",
         allowUnverifiedAgent: false,
@@ -797,17 +798,17 @@ describe("index", () => {
     });
 
     it("should keep the default when the concurrency value is missing or not a number", () => {
-      expect(parseGatewayArgs(["--max-concurrency"]).maxConcurrency).toBe(2);
-      expect(parseGatewayArgs(["--max-concurrency", "many"]).maxConcurrency).toBe(2);
+      expect(parseGatewayArgs(["--max-concurrency"]).maxConcurrency).toBe(1);
+      expect(parseGatewayArgs(["--max-concurrency", "many"]).maxConcurrency).toBe(1);
       expect(parseGatewayArgs(["--max-concurrency", "--logout"])).toMatchObject({
-        maxConcurrency: 2,
+        maxConcurrency: 1,
         command: "logout",
       });
     });
 
     it("should read the preferred auth method", () => {
       expect(parseGatewayArgs(["--auth-method", "oauth"])).toMatchObject({
-        maxConcurrency: 2,
+        maxConcurrency: 1,
         command: "run",
         authMethodId: "oauth",
       });
@@ -815,9 +816,9 @@ describe("index", () => {
     });
 
     it("should recognise the auth commands", () => {
-      expect(parseGatewayArgs(["--login"])).toMatchObject({ maxConcurrency: 2, command: "login" });
+      expect(parseGatewayArgs(["--login"])).toMatchObject({ maxConcurrency: 1, command: "login" });
       expect(parseGatewayArgs(["--login", "oauth"])).toMatchObject({
-        maxConcurrency: 2,
+        maxConcurrency: 1,
         command: "login",
         authMethodId: "oauth",
       });
@@ -949,7 +950,7 @@ describe("index", () => {
 
   describe("resolveAgentCommand", () => {
     const options = (overrides: Record<string, any> = {}) => ({
-      maxConcurrency: 2,
+      maxConcurrency: 1,
       permissionTimeoutMs: 30 * 60_000,
       command: "run" as const,
       allowUnverifiedAgent: false,
@@ -1211,6 +1212,10 @@ describe("index", () => {
 
     it("should say why an unverified agent is not installed by default", () => {
       expect(helpText()).toMatch(/no way to tell what was downloaded/);
+    });
+
+    it("should document the default concurrency of 1", () => {
+      expect(helpText()).toContain("Defaults to 1.");
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -829,6 +829,9 @@ export type GatewayCommand =
   | "agent-info"
   | "help";
 
+/** Default maximum number of concurrent tasks allowed to prompt the ACP agent at once. */
+export const DEFAULT_MAX_CONCURRENCY = 1;
+
 export interface GatewayOptions {
   maxConcurrency: number;
   /** How long a tool call waits for a human verdict. 0 waits indefinitely. */
@@ -852,7 +855,7 @@ export interface GatewayOptions {
  */
 export function parseGatewayArgs(args: string[]): GatewayOptions {
   const options: GatewayOptions = {
-    maxConcurrency: 2,
+    maxConcurrency: DEFAULT_MAX_CONCURRENCY,
     permissionTimeoutMs: DEFAULT_PERMISSION_TIMEOUT_MS,
     command: "run",
     allowUnverifiedAgent: false,
@@ -1190,7 +1193,7 @@ AUTHENTICATION
 
 BRIDGE
   --max-concurrency <number>  How many tasks may prompt the agent at once.
-                              Defaults to 2.
+                              Defaults to ${DEFAULT_MAX_CONCURRENCY}.
   --permission-timeout <min>  How long a tool call waits for someone to approve
                               it before the turn is cancelled. Defaults to 30.
                               0 waits indefinitely, which is what a wedged


### PR DESCRIPTION
## What changed
Decreased the default task concurrency limit to 1 so the gateway processes one task at a time unless explicitly configured otherwise.

## Why changed
Running tasks sequentially by default prevents resource contention and ensures deterministic single-agent execution unless higher concurrency is deliberately opted into.

## Test coverage report
New lines introduced 100%, total coverage impact:
- Statements: 88.04% (1149/1305)
- Branches: 89.59% (766/855)
- Functions: 87.55% (204/233)
- Lines: 87.80% (1058/1205)

## TaskID
TaskID: 0iEsG4arDyj

---
Generated with [AgentRQ](https://agentrq.com)