### PR TITLE
chore: bump version to 0.2.10 (TaskID: 0iHCmceBd45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install -g @agentrq/acp-gateway
 
 ## Current Version
 
-`0.2.9`
+`0.2.10`
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentrq/acp-gateway",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.4.0",
         "@modelcontextprotocol/sdk": "^1.30.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "ACP+MCP bridge CLI for agentrq workspaces",
   "type": "module",
   "publishConfig": {

--- a/src/mcpClient.ts
+++ b/src/mcpClient.ts
@@ -96,7 +96,7 @@ export class MCPBridge extends EventEmitter {
     this.client = new Client(
       {
         name: "acp-gateway",
-        version: "0.2.9",
+        version: "0.2.10",
       },
       {
         capabilities: {},


### PR DESCRIPTION
## What changed

Bumps the released version to 0.2.10, covering the Windows fix that just landed: npm-distributed registry agents now start on Windows instead of failing with a command-not-found error before the gateway even runs.

## Why changed

The Windows fix (#58) is on main and needs a release for the users who reported it. The version is stated in four places — the package manifest, the lockfile, the README and the identity the gateway gives the workspace over MCP — and all four move together.

## Test coverage report

- **New lines: 100%** — no new logic, only version strings; nothing added to cover.
- **Total coverage impact:** none — statements 88.40%, branches 90.05%, functions 88.06%, lines 88.09%, unchanged from main.
- 424 tests pass, typecheck clean.

## Other reports

Tagging `v0.2.10` on main after this merges publishes to npm via CI.

TaskID: 0iHCmceBd45

---
Generated with [AgentRQ](https://agentrq.com)