### PR TITLE
chore: bump version to 0.2.11 (TaskID: 0iLDmVtzPtZ)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install -g @agentrq/acp-gateway
 
 ## Current Version
 
-`0.2.10`
+`0.2.11`
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentrq/acp-gateway",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.4.0",
         "@modelcontextprotocol/sdk": "^1.30.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "ACP+MCP bridge CLI for agentrq workspaces",
   "type": "module",
   "publishConfig": {

--- a/src/mcpClient.ts
+++ b/src/mcpClient.ts
@@ -96,7 +96,7 @@ export class MCPBridge extends EventEmitter {
     this.client = new Client(
       {
         name: "acp-gateway",
-        version: "0.2.10",
+        version: "0.2.11",
       },
       {
         capabilities: {},


### PR DESCRIPTION
## What changed

Bumps the released version to 0.2.11, covering recent updates including decreasing default concurrency to 1 and PATH resolution test fixes.

## Why changed

Releases the latest changes on main to npm. All references across the package manifest, lockfile, documentation, and MCP client identity have been updated in lockstep.

## Test coverage report

- **New lines: 100%** — no new logic, only version strings; nothing added to cover.
- **Total coverage impact:** none — statements 88.41%, branches 90.05%, functions 88.06%, lines 88.10%, unchanged from main.
- 425 tests pass, typecheck clean.

## Other reports

Tagging `v0.2.11` on main after this merges publishes to npm via CI.

TaskID: 0iLDmVtzPtZ

---
Generated with [AgentRQ](https://agentrq.com)