### PR TITLE
fix: take the patched qs to clear two Dependabot advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2823,9 +2823,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",


### PR DESCRIPTION
## What changed

Moved a transitively-installed query-string parser to its patched release, clearing the two advisories Dependabot reported. Lockfile only — no dependency bump and no source change.

## Why changed

The installed `qs` 6.15.3 carries a moderate array-limit bypass (GHSA-x5fp-wj9c-mxmx) and a denial of service via an attacker-controlled `isBuffer` (GHSA-4mjr-xmp4-gh2g). Version 6.16.0 fixes both and satisfies the ranges `express` and `body-parser` already ask for, so nothing else has to move.

## Test coverage report

- **New lines introduced: 100%** — vacuously, as no source lines were added or changed; the whole diff is three lines of `package-lock.json`.
- **Total coverage impact: none.** Statements 88.85%, branches 90.50%, functions 88.44%, lines 88.48% — identical before and after.
- Full suite: 458 tests passing, `tsc` build clean.

## Other reports

- `npm audit` goes from `1 moderate severity vulnerability` to `found 0 vulnerabilities`.
- Reachability: the affected code was never loaded at runtime. `qs` arrives via the MCP SDK's server-side `express` modules, and this gateway imports only `client/index.js` and `client/streamableHttp.js` — verified by checking which SDK files import `express`. The alert described the dependency graph rather than a live exposure, but the upgrade is free, so there was no reason to carry it.
- The Dependabot dashboard itself could not be read from this environment (the API returns 403 for the available token), so the alert set was reproduced with `npm audit`, which draws on the same GitHub Advisory Database.

TaskID: 0iON9tV3bNZ

---

Generated with [AgentRQ](https://agentrq.com)