### PR TITLE
chore: bump version to 0.2.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install -g @agentrq/acp-gateway
 
 ## Current Version
 
-`0.2.11`
+`0.2.12`
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentrq/acp-gateway",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.4.0",
         "@modelcontextprotocol/sdk": "^1.30.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "ACP+MCP bridge CLI for agentrq workspaces",
   "type": "module",
   "publishConfig": {

--- a/src/mcpClient.ts
+++ b/src/mcpClient.ts
@@ -143,7 +143,7 @@ export class MCPBridge extends EventEmitter {
     this.client = new Client(
       {
         name: "acp-gateway",
-        version: "0.2.11",
+        version: "0.2.12",
       },
       {
         capabilities: {},


### PR DESCRIPTION
## What changed

The package version moves from 0.2.11 to 0.2.12 — the published version, the version the gateway introduces itself to the workspace with, and the one the README quotes, all kept in step.

## Why changed

To release the three fixes merged since 0.2.11: file reads now honour the line and limit bounds an agent asks for, the workspace's own tool calls are auto-approved whatever its MCP server is named, and a transitively-installed query-string parser was moved off two advisories.

## Test coverage report

- **New lines introduced: 100%** — vacuously, as no logic was added or changed; the diff is four version strings.
- **Total coverage impact: none.** Statements 88.85%, branches 90.50%, functions 88.44%, lines 88.48% — unchanged.
- Full suite: 458 tests passing, `tsc --noEmit` clean.

## Other reports

Release contents, all merged to main and included here:

| PR | Change |
|----|--------|
| #62 | `fs/read_text_file` honours the `line` and `limit` bounds of an ACP read request |
| #63 | The workspace's own tools are auto-approved whatever its server is named, verified against the tools it advertises |
| #65 | `qs` moved to 6.16.0, clearing GHSA-x5fp-wj9c-mxmx and GHSA-4mjr-xmp4-gh2g |

No dependency ranges changed in this PR. Tagging is deliberately left out: pushing a `v0.2.12` tag is what triggers the npm publish workflow, so that belongs after this merges.

TaskID: 0iOORIX5DE1

---

Generated with [AgentRQ](https://agentrq.com)