### PR TITLE
chore: bump version to 0.2.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install -g @agentrq/acp-gateway
 
 ## Current Version
 
-`0.2.12`
+`0.2.13`
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentrq/acp-gateway",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.4.0",
         "@modelcontextprotocol/sdk": "^1.30.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "ACP+MCP bridge CLI for agentrq workspaces",
   "type": "module",
   "publishConfig": {

--- a/src/mcpClient.ts
+++ b/src/mcpClient.ts
@@ -143,7 +143,7 @@ export class MCPBridge extends EventEmitter {
     this.client = new Client(
       {
         name: "acp-gateway",
-        version: "0.2.12",
+        version: "0.2.13",
       },
       {
         capabilities: {},


### PR DESCRIPTION
## What changed

The package version moves from 0.2.12 to 0.2.13 across all published and configured version references.

## Why changed

To release the features and updates merged since 0.2.12: forwarding slash commands advertised by an ACP agent to the workspace, and updating the license copyright year and owner.

## Test coverage report

- **New lines introduced: 100%** — no logic was added or changed; the diff consists solely of version strings.
- **Total coverage impact: none.** Statements 89.16%, branches 90.90%, functions 88.58%, lines 88.71% — unchanged.
- Full suite: 473 tests passing, `tsc --noEmit` clean.

## Other reports

Release contents merged to main since 0.2.12:

| PR | Change |
|----|--------|
| #67 | Update copyright year and owner in LICENSE file |
| #68 | Forward the slash commands an ACP agent advertises (`available_commands_update`) |

TaskID: 0iRIOemUap7

---

Generated with [AgentRQ](https://agentrq.com)