### PR TITLE
chore: bump version to 0.2.14 (TaskID: 0iRgqquRrnd)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install -g @agentrq/acp-gateway
 
 ## Current Version
 
-`0.2.13`
+`0.2.14`
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentrq/acp-gateway",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.4.0",
         "@modelcontextprotocol/sdk": "^1.30.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "ACP+MCP bridge CLI for agentrq workspaces",
   "type": "module",
   "publishConfig": {

--- a/src/mcpClient.ts
+++ b/src/mcpClient.ts
@@ -143,7 +143,7 @@ export class MCPBridge extends EventEmitter {
     this.client = new Client(
       {
         name: "acp-gateway",
-        version: "0.2.13",
+        version: "0.2.14",
       },
       {
         capabilities: {},


### PR DESCRIPTION
## What changed

Bumped the package patch version from 0.2.13 to 0.2.14.

## Why changed

To release the latest changes including reporting the ACP agent identity to the agentrq workspace.

## Test coverage report

- New lines introduced: 100%
- Total coverage impact: 0% (statements 89.31%, branches 90.96%, functions 88.67%, lines 88.86%)
- Full test suite: 482 passing tests across 12 test files.

## Other reports

Changes included in this release:
- #70: feat: tell the workspace which agent is behind the gateway

TaskID: 0iRgqquRrnd

---
Generated with [AgentRQ](https://agentrq.com)