### PR TITLE
fix: five defects in the startup session, and advice for agents that never log in

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -640,7 +640,7 @@ describe("index", () => {
       const outcome = await openIdleSession(["node", "agent.js"], [], { env: {} } as any, mockBridge);
 
       expect(outcome).toBe("unauthenticated");
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("needs you to log in"));
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("until it is authenticated"));
       expect(activeSessions.has(IDLE_SESSION_KEY)).toBe(false);
       // Nothing was claimed about an agent that never started.
       expect(mockBridge.sendNotification).not.toHaveBeenCalledWith(
@@ -665,7 +665,27 @@ describe("index", () => {
       const outcome = await openIdleSession(["node", "agent.js"], [], { env: {} } as any, mockBridge);
 
       expect(outcome).toBe("unauthenticated");
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("needs you to log in"));
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Log in and run acp-gateway again"));
+      consoleSpy.mockRestore();
+    });
+
+    it("tells the owner of an API-key agent to set the key, not to log in", async () => {
+      // Plenty of agents never ask anyone to log in — they read a key from the
+      // environment. When one of those refuses, sending its owner looking for a
+      // login prompt that does not exist is worse than saying nothing.
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const mockBridge: any = fakeBridge();
+      newSessionError.value = new AuthenticationFailed(new Error("auth_required"), false);
+
+      const outcome = await openIdleSession(["node", "agent.js"], [], { env: {} } as any, mockBridge);
+
+      expect(outcome).toBe("unauthenticated");
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("expecting a credential of its own"),
+      );
+      expect(consoleSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("Log in and run acp-gateway again."),
+      );
       consoleSpy.mockRestore();
     });
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -11,10 +11,10 @@ import {
   mapMcpServers,
   TaskQueue,
   getOrCreateSession,
-  isLoginRefusal,
   openIdleSession,
   resetIdleSession,
   activeSessions,
+  AuthenticationFailed,
   IDLE_SESSION_KEY,
   authConfig,
   modelConfig,
@@ -87,8 +87,10 @@ vi.mock("node:child_process", async () => {
 });
 
 /** Lets a test make the next `session/new` fail, e.g. with auth_required. */
-const { newSessionError } = vi.hoisted(() => ({
+const { newSessionError, newSessionHangs } = vi.hoisted(() => ({
   newSessionError: { value: null as unknown },
+  /** Lets a test make `session/new` never answer, like an agent gone quiet. */
+  newSessionHangs: { value: false },
 }));
 
 vi.mock("@agentclientprotocol/sdk", async () => {
@@ -99,6 +101,7 @@ vi.mock("@agentclientprotocol/sdk", async () => {
       return {
         initialize: vi.fn().mockResolvedValue({ protocolVersion: "0.1.0" }),
         newSession: vi.fn().mockImplementation(async () => {
+          if (newSessionHangs.value) return new Promise(() => {});
           if (newSessionError.value) throw newSessionError.value;
           return { sessionId: "test-sess-123" };
         }),
@@ -529,6 +532,7 @@ describe("index", () => {
       activeSessions.clear();
       resetIdleSession();
       newSessionError.value = null;
+      newSessionHangs.value = false;
     });
 
     it("should spawn a new session when not cached", async () => {
@@ -613,9 +617,10 @@ describe("index", () => {
       const mockBridge: any = fakeBridge();
       newSessionError.value = new Error("agent will not start");
 
+      // Survivable: it says the gateway can carry on, and the first task retries.
       await expect(
         openIdleSession(["node", "agent.js"], [], { env: {} } as any, mockBridge),
-      ).resolves.toBeUndefined();
+      ).resolves.toBe("unknown");
 
       expect(activeSessions.has(IDLE_SESSION_KEY)).toBe(false);
       expect(consoleSpy).toHaveBeenCalledWith(
@@ -625,23 +630,17 @@ describe("index", () => {
       consoleSpy.mockRestore();
     });
 
-    it("shuts the gateway down when the agent cannot be authenticated", async () => {
+    it("reports that the gateway cannot continue when the agent is unauthenticated", async () => {
       // Carrying on would leave the workspace showing a live agent that fails
       // every task it is given, which is worse than not running at all.
       const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       const mockBridge: any = fakeBridge();
-      const onUnauthenticated = vi.fn();
       newSessionError.value = { code: -32000, data: { authRequired: true }, message: "auth_required" };
 
-      await openIdleSession(
-        ["node", "agent.js"],
-        [],
-        { env: {} } as any,
-        mockBridge,
-        onUnauthenticated,
-      );
+      const outcome = await openIdleSession(["node", "agent.js"], [], { env: {} } as any, mockBridge);
 
-      expect(onUnauthenticated).toHaveBeenCalledOnce();
+      expect(outcome).toBe("unauthenticated");
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("needs you to log in"));
       expect(activeSessions.has(IDLE_SESSION_KEY)).toBe(false);
       // Nothing was claimed about an agent that never started.
       expect(mockBridge.sendNotification).not.toHaveBeenCalledWith(
@@ -651,46 +650,45 @@ describe("index", () => {
       consoleSpy.mockRestore();
     });
 
-    it("says what to do about it, and stops the process", async () => {
-      // The default behaviour, with nothing injected: this is what a human
-      // actually sees when their agent is not logged in.
+    it("shuts down when the login itself went wrong", async () => {
+      // A terminal login the human abandoned, a login subcommand exiting
+      // non-zero, no usable method on a headless run: all of them come back as
+      // AuthenticationFailed, so none of them has to be recognised by its
+      // message. The conclusion is the same — an agent that cannot authenticate
+      // cannot work.
       const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      const exitSpy = vi
-        .spyOn(process, "exit")
-        .mockImplementation((() => undefined) as never);
       const mockBridge: any = fakeBridge();
-      newSessionError.value = { code: -32000, data: { authRequired: true }, message: "auth_required" };
-
-      await openIdleSession(["node", "agent.js"], [], { env: {} } as any, mockBridge);
-
-      expect(exitSpy).toHaveBeenCalledWith(1);
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining("needs you to log in"),
+      newSessionError.value = new AuthenticationFailed(
+        new Error('Terminal login "oauth" failed (code=1, signal=null).'),
       );
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Nothing was started"));
-      exitSpy.mockRestore();
+
+      const outcome = await openIdleSession(["node", "agent.js"], [], { env: {} } as any, mockBridge);
+
+      expect(outcome).toBe("unauthenticated");
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("needs you to log in"));
       consoleSpy.mockRestore();
     });
 
-    it("shuts down when a headless run has no way to log in", async () => {
-      // What `login` throws when there is nobody to ask. Same conclusion: an
-      // agent that cannot authenticate cannot work.
+    it("gives up waiting on an agent that never opens a session", async () => {
+      // Nothing reaches the workspace until this settles, so an agent that
+      // spawns and then goes quiet would otherwise take the whole gateway with
+      // it — a worse failure than the one the startup session fixes.
       const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       const mockBridge: any = fakeBridge();
-      const onUnauthenticated = vi.fn();
-      newSessionError.value = new Error(
-        "No usable authentication method. Available:\n  oauth\nTerminal logins need an interactive terminal;",
-      );
+      newSessionHangs.value = true;
 
-      await openIdleSession(
+      const outcome = await openIdleSession(
         ["node", "agent.js"],
         [],
         { env: {} } as any,
         mockBridge,
-        onUnauthenticated,
+        20,
       );
 
-      expect(onUnauthenticated).toHaveBeenCalledOnce();
+      expect(outcome).toBe("unknown");
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("has not opened a session"),
+      );
       consoleSpy.mockRestore();
     });
 
@@ -699,18 +697,12 @@ describe("index", () => {
       // when the first task arrived, and it still should.
       const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       const mockBridge: any = fakeBridge();
-      const onUnauthenticated = vi.fn();
       newSessionError.value = new Error("spawn ENOENT");
 
-      await openIdleSession(
-        ["node", "agent.js"],
-        [],
-        { env: {} } as any,
-        mockBridge,
-        onUnauthenticated,
-      );
+      const outcome = await openIdleSession(["node", "agent.js"], [], { env: {} } as any, mockBridge);
 
-      expect(onUnauthenticated).not.toHaveBeenCalled();
+      // Survivable, so the gateway keeps running.
+      expect(outcome).toBe("unknown");
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining("the first task will start one"),
         expect.anything(),
@@ -2450,21 +2442,5 @@ describe("index", () => {
         cleanup();
       });
     });
-  });
-});
-
-describe("isLoginRefusal", () => {
-  it("recognises login giving up, which nobody can act on from the gateway", () => {
-    expect(isLoginRefusal(new Error("No usable authentication method. Available:\n  oauth"))).toBe(true);
-    expect(isLoginRefusal(new Error('Unknown authentication method "nope". Available:'))).toBe(true);
-  });
-
-  it("does not mistake an agent falling over for a login problem", () => {
-    // These are survivable; treating them as auth would shut the gateway down
-    // over a transient failure.
-    expect(isLoginRefusal(new Error("spawn ENOENT"))).toBe(false);
-    expect(isLoginRefusal(new Error("socket hang up"))).toBe(false);
-    expect(isLoginRefusal("not an error at all")).toBe(false);
-    expect(isLoginRefusal(undefined)).toBe(false);
   });
 });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -16,6 +16,7 @@ import {
   activeSessions,
   AuthenticationFailed,
   IDLE_SESSION_KEY,
+  loginCommandFor,
   authConfig,
   modelConfig,
   createSessionWithAuth,
@@ -665,7 +666,9 @@ describe("index", () => {
       const outcome = await openIdleSession(["node", "agent.js"], [], { env: {} } as any, mockBridge);
 
       expect(outcome).toBe("unauthenticated");
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Log in and run acp-gateway again"));
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("npx @agentrq/acp-gateway@latest --login"),
+      );
       consoleSpy.mockRestore();
     });
 
@@ -684,7 +687,7 @@ describe("index", () => {
         expect.stringContaining("expecting a credential of its own"),
       );
       expect(consoleSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining("Log in and run acp-gateway again."),
+        expect.stringContaining("--login"),
       );
       consoleSpy.mockRestore();
     });
@@ -702,6 +705,7 @@ describe("index", () => {
         [],
         { env: {} } as any,
         mockBridge,
+        loginCommandFor("some-agent"),
         20,
       );
 
@@ -2462,5 +2466,23 @@ describe("index", () => {
         cleanup();
       });
     });
+  });
+});
+
+describe("loginCommandFor", () => {
+  it("names the agent, so nobody has to work the command out", () => {
+    expect(loginCommandFor("antigravity-acp")).toBe(
+      "npx @agentrq/acp-gateway@latest --login --agent antigravity-acp",
+    );
+  });
+
+  it("repeats the command after -- when no registry id named the agent", () => {
+    expect(loginCommandFor(undefined, ["node", "my-agent.js"])).toBe(
+      "npx @agentrq/acp-gateway@latest --login -- node my-agent.js",
+    );
+  });
+
+  it("falls back to the bare command when nothing identifies the agent", () => {
+    expect(loginCommandFor()).toBe("npx @agentrq/acp-gateway@latest --login");
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -682,14 +682,25 @@ export async function createSessionWithAuth(
       await login({ ...auth, connection: connection as unknown as AuthConnection });
       return await connection.newSession(params);
     } catch (authErr) {
-      throw new AuthenticationFailed(authErr);
+      throw new AuthenticationFailed(authErr, Boolean(auth.methods?.length));
     }
   }
 }
 
-/** An agent that could not be authenticated, however the login went wrong. */
+/**
+ * An agent that could not be authenticated, however the login went wrong.
+ *
+ * `hasLogin` says whether the agent offered a way in at all. An agent that
+ * advertises none is not asking to be logged in — it wants a credential it
+ * reads for itself, an API key in the environment or a file on disk — and
+ * telling its owner to log in would send them looking for a prompt that does
+ * not exist.
+ */
 export class AuthenticationFailed extends Error {
-  constructor(readonly cause: unknown) {
+  constructor(
+    readonly cause: unknown,
+    readonly hasLogin: boolean = true,
+  ) {
     super(cause instanceof Error ? cause.message : String(cause));
     this.name = "AuthenticationFailed";
   }
@@ -919,10 +930,17 @@ export async function openIdleSession(
     return "ready";
   } catch (err) {
     if (err instanceof AuthenticationFailed || isAuthRequiredError(err)) {
+      const remedy =
+        err instanceof AuthenticationFailed && !err.hasLogin
+          ? `It offers no way to log in through acp-gateway, so it is expecting a credential ` +
+            `of its own — an API key in the environment, or whatever its own documentation ` +
+            `asks for. Set that and run acp-gateway again.`
+          : `Log in and run acp-gateway again.`;
       console.error(
-        `\n[acp-gateway] The agent needs you to log in before it can do anything: ${err instanceof Error ? err.message : String(err)}\n` +
-          `Nothing was started. Log in and run acp-gateway again — carrying on would leave ` +
-          `the workspace showing a live agent that fails every task it is given.`,
+        `\n[acp-gateway] The agent will not start a session until it is authenticated: ` +
+          `${err instanceof Error ? err.message : String(err)}\n` +
+          `Nothing was started. ${remedy} Carrying on would leave the workspace showing a ` +
+          `live agent that fails every task it is given.`,
       );
       return "unauthenticated";
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -895,9 +895,13 @@ export async function openIdleSession(
   configs: McpServerConfig[],
   agentrqConfig: McpServerConfig,
   mcpBridge: MCPBridge,
+  loginCommand: string = loginCommandFor(),
   timeoutMs: number = IDLE_SESSION_TIMEOUT_MS,
 ): Promise<IdleSessionOutcome> {
   try {
+    // Cleared when the session itself settles rather than when this returns:
+    // after a timeout the session is still coming, and a task that arrives
+    // meanwhile should still wait for it instead of starting a second agent.
     idleSessionInFlight = getOrCreateSession(
       undefined,
       acpCmdArgs,
@@ -905,6 +909,10 @@ export async function openIdleSession(
       agentrqConfig,
       mcpBridge,
     );
+    const settled = idleSessionInFlight;
+    void settled.catch(() => {}).finally(() => {
+      if (idleSessionInFlight === settled) idleSessionInFlight = null;
+    });
     // Bounded: nothing reaches the workspace until this settles, so an agent
     // that spawns and then never answers its handshake would otherwise take the
     // whole gateway down with it — a worse failure than the one being fixed,
@@ -934,13 +942,14 @@ export async function openIdleSession(
         err instanceof AuthenticationFailed && !err.hasLogin
           ? `It offers no way to log in through acp-gateway, so it is expecting a credential ` +
             `of its own — an API key in the environment, or whatever its own documentation ` +
-            `asks for. Set that and run acp-gateway again.`
-          : `Log in and run acp-gateway again.`;
+            `asks for. Set that and start acp-gateway again.`
+          : `Log in with:\n\n    ${loginCommand}\n\nthen start acp-gateway again.`;
       console.error(
         `\n[acp-gateway] The agent will not start a session until it is authenticated: ` +
           `${err instanceof Error ? err.message : String(err)}\n` +
-          `Nothing was started. ${remedy} Carrying on would leave the workspace showing a ` +
-          `live agent that fails every task it is given.`,
+          `Nothing was started. ${remedy}\n` +
+          `Carrying on would leave the workspace showing a live agent that fails every task ` +
+          `it is given.`,
       );
       return "unauthenticated";
     }
@@ -950,9 +959,25 @@ export async function openIdleSession(
       err instanceof Error ? err.message : String(err),
     );
     return "unknown";
-  } finally {
-    idleSessionInFlight = null;
   }
+}
+
+/**
+ * The command that logs this agent in, so the message can name it rather than
+ * leave someone to work it out.
+ *
+ * Built from how the gateway itself was started: the registry id when there was
+ * one, and otherwise the command after `--`, since that is the only handle on
+ * an agent nobody named.
+ */
+export function loginCommandFor(
+  agentId?: string,
+  agentCommand: string[] = [],
+): string {
+  const base = "npx @agentrq/acp-gateway@latest --login";
+  if (agentId) return `${base} --agent ${agentId}`;
+  if (agentCommand.length) return `${base} -- ${agentCommand.join(" ")}`;
+  return base;
 }
 
 /**
@@ -964,8 +989,21 @@ export async function openIdleSession(
  */
 export type IdleSessionOutcome = "ready" | "unknown" | "unauthenticated";
 
-/** How long to wait for an agent to open its first session. */
-export const IDLE_SESSION_TIMEOUT_MS = 60_000;
+/**
+ * How long to wait for an agent to open its first session.
+ *
+ * Generous because the wait includes starting the agent, and an `npx`
+ * distribution downloads its package the first time it is spawned — a cold
+ * install of a large one on a slow line is minutes, not seconds. (A registry
+ * *binary* is already on disk by now: that download happens while the launch
+ * command is being resolved, before any of this.)
+ *
+ * Erring long costs little. A session that arrives after the deadline is still
+ * recorded, still reports what the agent offers, and is still adopted by the
+ * first task — the timeout only decides how long the gateway waits before
+ * connecting to the workspace without knowing those things yet.
+ */
+export const IDLE_SESSION_TIMEOUT_MS = 5 * 60_000;
 
 
 
@@ -1855,7 +1893,13 @@ async function main() {
     // sends notifications, and sending one opens the connection. A task pushed
     // between the connection opening and something listening for it is a task
     // dropped on the floor.
-    const idle = await openIdleSession(acpCmdArgs, configs, agentrqConfig, mcpBridge);
+    const idle = await openIdleSession(
+      acpCmdArgs,
+      configs,
+      agentrqConfig,
+      mcpBridge,
+      loginCommandFor(options.agentId, explicitCommand),
+    );
     if (idle === "unauthenticated") {
       // Nothing to unwind: the agent was terminated where it was spawned, and
       // the workspace connection below has not been opened yet.

--- a/src/index.ts
+++ b/src/index.ts
@@ -673,8 +673,25 @@ export async function createSessionWithAuth(
   } catch (err) {
     if (!isAuthRequiredError(err)) throw err;
     console.error("[auth] Agent requires authentication before a session can start.");
-    await login({ ...auth, connection: connection as unknown as AuthConnection });
-    return await connection.newSession(params);
+    // Everything from here is the login, so everything that goes wrong in it is
+    // an authentication failure — whether that is a refusal to pick a method, a
+    // terminal login the human abandoned, or the agent still saying no
+    // afterwards. Typing it here beats reading messages downstream and missing
+    // whichever one nobody thought of.
+    try {
+      await login({ ...auth, connection: connection as unknown as AuthConnection });
+      return await connection.newSession(params);
+    } catch (authErr) {
+      throw new AuthenticationFailed(authErr);
+    }
+  }
+}
+
+/** An agent that could not be authenticated, however the login went wrong. */
+export class AuthenticationFailed extends Error {
+  constructor(readonly cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause));
+    this.name = "AuthenticationFailed";
   }
 }
 
@@ -728,6 +745,14 @@ export async function getOrCreateSession(
     cwd: process.cwd(),
     mcpServers: mapMcpServers(configs, initResult.agentCapabilities),
   };
+
+  // From here on the agent is running but nothing is tracking it yet: it only
+  // reaches activeSessions once a session exists, and closeAllSessions can only
+  // close what is in there. So anything that goes wrong in between has to take
+  // the process with it, or it is left running with nothing attached — an agent
+  // that quits when its stdin closes gets away with it, and one with its own
+  // event loop, which is the sort that wants a login, does not.
+  try {
 
   // An agent that demands authentication stops here and waits, including at
   // startup — that is the point of starting a session then. A terminal is where
@@ -817,8 +842,12 @@ export async function getOrCreateSession(
       assignTask?.(nextTaskId);
     },
   };
-  activeSessions.set(sessionKey, sessionInfo);
-  return sessionInfo;
+    activeSessions.set(sessionKey, sessionInfo);
+    return sessionInfo;
+  } catch (err) {
+    terminateAgentProcess(agentProcess);
+    throw err;
+  }
 }
 
 /**
@@ -855,8 +884,8 @@ export async function openIdleSession(
   configs: McpServerConfig[],
   agentrqConfig: McpServerConfig,
   mcpBridge: MCPBridge,
-  onUnauthenticated: (message: string) => void = exitUnauthenticated,
-): Promise<void> {
+  timeoutMs: number = IDLE_SESSION_TIMEOUT_MS,
+): Promise<IdleSessionOutcome> {
   try {
     idleSessionInFlight = getOrCreateSession(
       undefined,
@@ -865,51 +894,62 @@ export async function openIdleSession(
       agentrqConfig,
       mcpBridge,
     );
-    await idleSessionInFlight;
+    // Bounded: nothing reaches the workspace until this settles, so an agent
+    // that spawns and then never answers its handshake would otherwise take the
+    // whole gateway down with it — a worse failure than the one being fixed,
+    // and a new one. On a timeout the gateway carries on; the session may still
+    // arrive, and the first task will adopt it if it does.
+    const timedOut = Symbol("timed out");
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const result = await Promise.race([
+      idleSessionInFlight,
+      new Promise<typeof timedOut>((resolve) => {
+        timer = setTimeout(() => resolve(timedOut), timeoutMs);
+      }),
+    ]);
+    if (timer) clearTimeout(timer);
+
+    if (result === timedOut) {
+      console.error(
+        `[acp] The agent has not opened a session after ${Math.round(timeoutMs / 1000)}s; ` +
+          "carrying on without knowing what it offers.",
+      );
+      return "unknown";
+    }
+    return "ready";
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (isAuthRequiredError(err) || isLoginRefusal(err)) {
-      onUnauthenticated(message);
-      return;
+    if (err instanceof AuthenticationFailed || isAuthRequiredError(err)) {
+      console.error(
+        `\n[acp-gateway] The agent needs you to log in before it can do anything: ${err instanceof Error ? err.message : String(err)}\n` +
+          `Nothing was started. Log in and run acp-gateway again — carrying on would leave ` +
+          `the workspace showing a live agent that fails every task it is given.`,
+      );
+      return "unauthenticated";
     }
     console.error(
       "[acp] Could not open a session to learn what the agent offers; " +
         "the first task will start one:",
-      message,
+      err instanceof Error ? err.message : String(err),
     );
+    return "unknown";
   } finally {
     idleSessionInFlight = null;
   }
 }
 
 /**
- * Whether a failed session was `login` giving up rather than the agent falling
- * over.
+ * What came of trying to open a session before any task.
  *
- * `login` throws a plain Error for the two cases nobody can act on from here —
- * an unknown `--auth-method`, and no usable method at all, which is what a
- * headless run hits — so the message is what distinguishes them. Matching on it
- * is uncomfortable, and it is still better than treating "cannot authenticate"
- * as a transient hiccup and handing the workspace an agent that will fail
- * everything it is given.
+ * `ready` means the agent is up and has said what it is — including its own
+ * name, so nothing else should name it. `unknown` means the gateway is running
+ * but cannot describe its agent. `unauthenticated` means it never will.
  */
-export function isLoginRefusal(err: unknown): boolean {
-  const message = err instanceof Error ? err.message : "";
-  return (
-    message.startsWith("No usable authentication method") ||
-    message.startsWith("Unknown authentication method")
-  );
-}
+export type IdleSessionOutcome = "ready" | "unknown" | "unauthenticated";
 
-/** Stops the gateway, saying what has to happen before it can run. */
-function exitUnauthenticated(message: string): never {
-  console.error(
-    `\n[acp-gateway] The agent needs you to log in before it can do anything: ${message}\n` +
-      `Nothing was started. Log in and run acp-gateway again — carrying on would leave ` +
-      `the workspace showing a live agent that fails every task it is given.`,
-  );
-  return process.exit(1);
-}
+/** How long to wait for an agent to open its first session. */
+export const IDLE_SESSION_TIMEOUT_MS = 60_000;
+
+
 
 export function findActiveSession(taskId?: string): AgentSession | undefined {
   if (taskId) {
@@ -919,10 +959,15 @@ export function findActiveSession(taskId?: string): AgentSession | undefined {
       if (session.sessionId === taskId) return session;
     }
     // A session opened from a notification that carried no task id is keyed
-    // "default"; when it is the only one running, an id-carrying cancel can
-    // only have meant it. Never fall back to a session keyed under a
+    // under IDLE_SESSION_KEY; when it is the only one running, an id-carrying
+    // cancel can only have meant it. Never fall back to a session keyed under a
     // *different* task id — that would abort an unrelated task.
-    const untracked = activeSessions.get("default");
+    //
+    // The session opened at startup shares that key until a task adopts it, so
+    // this can now match one that has never run anything. That stays correct
+    // either way: if it was reused for a task-less prompt it is the session the
+    // cancel meant, and if it is untouched it has no turn to cancel.
+    const untracked = activeSessions.get(IDLE_SESSION_KEY);
     if (untracked && activeSessions.size === 1) {
       return untracked;
     }
@@ -1792,14 +1837,23 @@ async function main() {
     // sends notifications, and sending one opens the connection. A task pushed
     // between the connection opening and something listening for it is a task
     // dropped on the floor.
-    await openIdleSession(acpCmdArgs, configs, agentrqConfig, mcpBridge);
+    const idle = await openIdleSession(acpCmdArgs, configs, agentrqConfig, mcpBridge);
+    if (idle === "unauthenticated") {
+      // Nothing to unwind: the agent was terminated where it was spawned, and
+      // the workspace connection below has not been opened yet.
+      removeSignalHandlers();
+      process.exit(1);
+    }
 
     await mcpBridge.connect();
 
-    // Name the agent now there is somewhere to say it. The registry's answer is
-    // the one available before the agent has spoken for itself, and the agent's
-    // own word replaces it as soon as it has one.
-    if (resolved.identity) {
+    // Only when the agent has not spoken for itself. A session that came up
+    // already reported the agent's own name, title and version from its
+    // handshake, and the registry's entry is a coarser answer to the same
+    // question — sending it after would replace what the agent said about
+    // itself with what an index says about it, dropping the title and swapping
+    // the running version for a published one.
+    if (idle !== "ready" && resolved.identity) {
       void sendAgentIdentity(mcpBridge, resolved.identity);
     }
 

--- a/src/mcpClient.ts
+++ b/src/mcpClient.ts
@@ -81,7 +81,11 @@ export class MCPBridge extends EventEmitter {
   }
 
   async connect() {
-    if (this.isConnecting || this.isConnected) return;
+    if (this.isConnected) return;
+    // Already coming up — wait for that attempt rather than returning as though
+    // the connection were made. A caller that awaits this is asking to be
+    // connected, and something else having started the job first is no answer.
+    if (this.isConnecting) return this.waitUntilConnected();
     this.isConnecting = true;
     this.isClosed = false;
 
@@ -236,6 +240,20 @@ export class MCPBridge extends EventEmitter {
     );
 
     await this.refreshAdvertisedTools();
+  }
+
+  /**
+   * Waits for a connection attempt already in progress.
+   *
+   * Bounded, because the retry loop backs off indefinitely and a caller that
+   * waited forever would never reach whatever it meant to do once connected.
+   */
+  private async waitUntilConnected(timeoutMs = 10_000): Promise<void> {
+    let waited = 0;
+    while (!this.isConnected && waited < timeoutMs) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      waited += 100;
+    }
   }
 
   private async ensureConnected() {


### PR DESCRIPTION
## What changed

Five defects in the startup session that #73 introduced or exposed — the most serious being that the agent's own name was overwritten by the registry's — plus advice that was wrong for agents which authenticate from their environment rather than by logging in.

## Why changed

A code review of #73 after it merged. Each is described in the commit; the short version:

- **The registry name overwrote the agent's own** (high). Opening the session before connecting meant the agent's identity — name, title and version from its handshake — was sent first, and the registry's coarser entry after it. Last write wins, so the running agent's version was replaced by whatever the index published and the title was dropped. That inverts the precedence #503 and the README both state. The registry entry is now sent only when no session came up to say something better.
- **A spawned agent could be left running with nothing attached.** It only reaches the session registry once a session exists, so a failure in between — an agent refusing to authenticate, most likely — left the process running. An agent that quits when its stdin closes got away with it; one with its own event loop, which is exactly the sort that wants a login, did not.
- **A login that went wrong was treated as survivable.** Only the JSON-RPC code and two of the login helper's messages were recognised, so a terminal login the human abandoned left the gateway up with an agent that would fail every task — the outcome the change exists to prevent. Everything the login throws is now typed where it happens rather than recognised by its message afterwards.
- **`connect()` could return without connecting.** It returns early when a connection is already being made, and sending the session's notifications starts one. A caller that awaits it is asking to be connected, so it now waits for the attempt already running.
- **A hung agent could take the gateway with it.** Nothing reaches the workspace until the startup session settles, and neither the handshake nor `session/new` has a deadline. Bounded now — at five minutes, because the wait includes starting the agent and an `npx` distribution downloads its package the first time it is spawned. Erring long costs little: a session that arrives late is still recorded, still reports what the agent offers, and is still adopted by the first task. The in-flight session also survives the deadline, so a task arriving between the timeout and the session landing no longer starts a second agent.

## Test coverage report

- **New lines: 100%** of what is reachable — everything except the call sites inside `main()`, which has no harness.
- **Total coverage impact:** unchanged; 498 tests pass.
- New tests: an abandoned login is classified as unauthenticated whatever its message; an agent that never opens a session times out and the gateway carries on; and the existing outcome tests were rewritten around the tri-state the identity fix needed.

## Other reports

Both of the behavioural fixes were verified against a local instance rather than only in tests.

The identity fix, driving the registry path where the clobber happened — a stub agent naming itself `fake-codex 9.9.9` behind a registry entry called `Registry Display Name 0.0.1-registry`:

```
[acp] Told the workspace it is talking to "fake-codex"      ← once, not twice
agentClient = {"name":"fake-codex","title":"Fake Codex","version":"9.9.9"}
```

The orphan fix, with an agent that ignores stdin closing:

```
before the fix:  gateway exit 1, agent still running
after the fix:   gateway exit 1, agent gone
```

**Not every ACP agent has a login.** Many read a credential for themselves — an API key in the environment, a file on disk — and advertise no authentication methods. Those never touch this code while their credential is present; `session/new` simply succeeds, which is verified. When one is missing its key it still refuses, and stopping is still right, but the message used to send its owner looking for a login prompt that does not exist. The two cases are now told apart:

```
offers a login:  Nothing was started. Log in and run acp-gateway again.
offers none:     Nothing was started. It offers no way to log in through acp-gateway, so it
                 is expecting a credential of its own — an API key in the environment, or
                 whatever its own documentation asks for. Set that and run acp-gateway again.
```

One review finding was considered and deliberately not changed: the cancel fallback can now match an unadopted startup session. It stays correct either way — if that session was reused for a task-less prompt it is the one the cancel meant, and if it is untouched it has no turn to cancel — so only the hardcoded key was replaced with the constant, to stop the two drifting.

**The message now names the command that fixes it**, with the agent's own name rather than a placeholder:

```
Nothing was started. Log in with:

    npx @agentrq/acp-gateway@latest --login --agent antigravity-acp

then start acp-gateway again.
```

A gateway started with a command after `--` gets that command back instead, since it is the only handle on an agent nobody named.

TaskID: 0iRlOKKl6wL
