### PR TITLE
chore: bump version to 0.2.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install -g @agentrq/acp-gateway
 
 ## Current Version
 
-`0.2.14`
+`0.2.15`
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentrq/acp-gateway",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.4.0",
         "@modelcontextprotocol/sdk": "^1.30.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "ACP+MCP bridge CLI for agentrq workspaces",
   "type": "module",
   "publishConfig": {

--- a/src/mcpClient.ts
+++ b/src/mcpClient.ts
@@ -147,7 +147,7 @@ export class MCPBridge extends EventEmitter {
     this.client = new Client(
       {
         name: "acp-gateway",
-        version: "0.2.14",
+        version: "0.2.15",
       },
       {
         capabilities: {},


### PR DESCRIPTION
## What changed

The gateway's version moves from 0.2.14 to 0.2.15.

## Why changed

To publish everything merged since 0.2.14, which is one story: a workspace can now say what its agent actually is — its name, the model it is on, the models it offers and the slash commands it accepts — before anyone has given it any work.

Shipping in this version:

**feat** — learning what the agent offers when it connects rather than on the first task (#73); naming the agent as soon as the workspace connection is up, from the registry, replaced by the agent's own word once it has spoken (#72).

**fix** — five defects in that startup session, found by reviewing it after it merged: the registry name overwrote the agent's own, a spawned agent could be left running after a failed login, an abandoned login counted as survivable, `connect()` could return without connecting, and a hung agent could take the gateway with it (#74). Plus: an agent that authenticates from its environment is no longer told to log in, and one that does have a login is now given the exact command to run (#74); and a polynomial-regex warning in the Windows argument quoting is cleared by counting backslash runs instead of backtracking over them (#73).

## Test coverage report

- **New lines introduced: none** — this is a version-string change only, and the line in the MCP client that carries it is exercised by the existing bridge tests.
- **Total coverage impact: none.**
- Verified: `tsc --noEmit` clean, 502 tests pass, and `npm ci` still resolves against the edited lockfile.

## Other reports

Four places carry the version and all four move together: the manifest, both lockfile entries, the client identity the gateway sends on the MCP handshake, and the README. The lockfile was edited by hand rather than regenerated, so dependency resolution does not shift underneath a release.

Merging this publishes nothing on its own — the release is cut by tagging.

TaskID: 0iRlOKKl6wL
