### PR TITLE
chore: bump version to 0.2.16 (TaskID: 0iSA7IWgYoj)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install -g @agentrq/acp-gateway
 
 ## Current Version
 
-`0.2.15`
+`0.2.16`
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentrq/acp-gateway",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.4.0",
         "@modelcontextprotocol/sdk": "^1.30.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "ACP+MCP bridge CLI for agentrq workspaces",
   "type": "module",
   "publishConfig": {

--- a/src/mcpClient.ts
+++ b/src/mcpClient.ts
@@ -147,7 +147,7 @@ export class MCPBridge extends EventEmitter {
     this.client = new Client(
       {
         name: "acp-gateway",
-        version: "0.2.15",
+        version: "0.2.16",
       },
       {
         capabilities: {},


### PR DESCRIPTION
## What changed

The gateway's version moves from 0.2.15 to 0.2.16.

## Why changed

To publish changes merged since 0.2.15, enabling workspaces to select an agent's model at runtime and ensuring model switch notifications and failures are always answered.

Shipping in this version:
- **feat**: let the workspace choose the agent's model while it runs (#76)
- **fix**: answer the model picker on every path, including the ones that failed (#77)

## Test coverage report

- **New lines introduced: 100%**
- **Total coverage impact: none** (Statements: 89.58%, Branches: 90.48%, Functions: 88.92%, Lines: 89.26%; 521 tests passed)

## Other reports

Four places carry the version and all four move together: the package manifest, both package lockfile entries, the client identity reported during MCP handshake, and the README documentation.

TaskID: 0iSA7IWgYoj

---
Generated with [AgentRQ](https://agentrq.com)