### PR TITLE
chore: bump version to 0.2.17 (TaskID: 0iSBGCTsPth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install -g @agentrq/acp-gateway
 
 ## Current Version
 
-`0.2.16`
+`0.2.17`
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentrq/acp-gateway",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.4.0",
         "@modelcontextprotocol/sdk": "^1.30.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentrq/acp-gateway",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "description": "ACP+MCP bridge CLI for agentrq workspaces",
   "type": "module",
   "publishConfig": {

--- a/src/mcpClient.ts
+++ b/src/mcpClient.ts
@@ -147,7 +147,7 @@ export class MCPBridge extends EventEmitter {
     this.client = new Client(
       {
         name: "acp-gateway",
-        version: "0.2.16",
+        version: "0.2.17",
       },
       {
         capabilities: {},


### PR DESCRIPTION
## What changed

The gateway version moves from 0.2.16 to 0.2.17.

## Why changed

To release the fixes for advertising all available models with wire format compatibility aliases and re-advertising models to workspaces upon task adoption.

Shipping in this version:
- **fix**: advertise all available models with wire aliases (#79)

## Test coverage report

- **New lines introduced: 100%**
- **Total coverage impact: none** (Statements: 89.63%, Branches: 90.56%, Functions: 88.96%, Lines: 89.32%; 523 tests passed)

## Other reports

Four places carry the version and all four move together: the package manifest, both package lockfile entries, the client identity reported during MCP handshake, and the README documentation.

TaskID: 0iSBGCTsPth

---
Generated with [AgentRQ](https://agentrq.com)